### PR TITLE
feat:add more filter replace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         entry: black
         types: [python]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         name: isort

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ style_check: static_type_check pylint
 test:
 	py.test --cov media_downloader --doctest-modules \
 		--cov utils \
-		--cov module/app.py \
 		--cov-report term-missing \
 		--cov-report html:${TEST_ARTIFACTS} \
 		--junit-xml=${TEST_ARTIFACTS}/media-downloader.xml \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ black==22.6.0
 isort==5.10.1
 mock==4.0.3
 mypy==0.971
-pre-commit==2.21.0
+pre-commit==2.20.0
 pylint==2.14.5
 pytest==7.2.1
 pytest-cov==3.0.0

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -546,7 +546,7 @@ def main():
         )
 
 
-def _load_config() -> str:
+def _load_config():
     """Load config"""
     app.load_config()
 

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -41,10 +41,9 @@ logging.getLogger("pyrogram.client").addFilter(LogFilter())
 logging.getLogger("pyrogram").setLevel(logging.WARNING)
 
 
-def _check_download_finish(media_size: int,
-                           download_path: str,
-                           ui_file_name: str,
-                           message_id: int):
+def _check_download_finish(
+    media_size: int, download_path: str, ui_file_name: str, message_id: int
+):
     """Check download task if finish
 
     Parameters
@@ -146,6 +145,7 @@ def _is_exist(file_path: str) -> bool:
     """
     return not os.path.isdir(file_path) and os.path.exists(file_path)
 
+
 # pylint: disable = R0912
 
 
@@ -170,8 +170,7 @@ async def _get_media_meta(
     """
     if _type in ["audio", "document", "video"]:
         # pylint: disable = C0301
-        file_format: Optional[str] = media_obj.mime_type.split(
-            "/")[-1]  # type: ignore
+        file_format: Optional[str] = media_obj.mime_type.split("/")[-1]  # type: ignore
     else:
         file_format = None
 
@@ -188,8 +187,7 @@ async def _get_media_meta(
     if _type in ["voice", "video_note"]:
         # pylint: disable = C0209
         file_format = media_obj.mime_type.split("/")[-1]  # type: ignore
-        file_save_path = app.get_file_save_path(
-            _type, dirname, datetime_dir_name)
+        file_save_path = app.get_file_save_path(_type, dirname, datetime_dir_name)
 
         file_name = os.path.join(
             file_save_path,
@@ -207,13 +205,12 @@ async def _get_media_meta(
         file_name_suffix = ".unknown"
         if not file_name:
             file_name_suffix = get_extension(
-                media_obj.file_id, getattr(media_obj, "mime_type", ""))
+                media_obj.file_id, getattr(media_obj, "mime_type", "")
+            )
         else:
-            #file_name = file_name.split(".")[0]
-            _, file_name_without_suffix = os.path.split(
-                os.path.normpath(file_name))
-            file_name, file_name_suffix = os.path.splitext(
-                file_name_without_suffix)
+            # file_name = file_name.split(".")[0]
+            _, file_name_without_suffix = os.path.split(os.path.normpath(file_name))
+            file_name, file_name_suffix = os.path.splitext(file_name_without_suffix)
 
         if caption:
             caption = _validate_title(caption)
@@ -225,12 +222,10 @@ async def _get_media_meta(
             file_name = f"{message.photo.file_unique_id}"
 
         gen_file_name = (
-            app.get_file_name(message.id, file_name,
-                              caption) + file_name_suffix
+            app.get_file_name(message.id, file_name, caption) + file_name_suffix
         )
 
-        file_save_path = app.get_file_save_path(
-            _type, dirname, datetime_dir_name)
+        file_save_path = app.get_file_save_path(_type, dirname, datetime_dir_name)
         file_name = os.path.join(file_save_path, gen_file_name)
         file_name = truncate_filename(file_name)
     return file_name, file_format
@@ -304,7 +299,8 @@ async def download_media(
                     # FIXME: if exist and not empty file skip
                     logger.info(
                         "id={} {} already download,download skipped.\n",
-                        message.id, ui_file_name,
+                        message.id,
+                        ui_file_name,
                     )
 
                     app.downloaded_ids.append(message.id)
@@ -342,7 +338,8 @@ async def download_media(
             if download_path and isinstance(download_path, str):
                 # TODO: if not exist file size or media
                 _check_download_finish(
-                    media_size, download_path, ui_file_name, message.id)
+                    media_size, download_path, ui_file_name, message.id
+                )
                 await app.upload_file(file_name)
 
             break
@@ -363,8 +360,7 @@ async def download_media(
                 )
         except pyrogram.errors.exceptions.flood_420.FloodWait as wait_err:
             await asyncio.sleep(wait_err.value)
-            logger.warning("Message[{}]: FlowWait {}",
-                           message.id, wait_err.value)
+            logger.warning("Message[{}]: FlowWait {}", message.id, wait_err.value)
             _check_timeout(retry, message.id)
         except TypeError:
             # pylint: disable = C0301

--- a/module/app.py
+++ b/module/app.py
@@ -1,4 +1,5 @@
 """Application module"""
+
 import os
 from typing import List, Optional
 
@@ -9,6 +10,7 @@ from module.cloud_drive import CloudDrive, CloudDriveConfig
 from module.filter import Filter
 from utils.format import replace_date_time
 from utils.meta_data import MetaData
+
 
 # pylint: disable = R0902
 

--- a/module/app.py
+++ b/module/app.py
@@ -44,20 +44,6 @@ class Application:
 
         self.reset()
 
-        try:
-            with open(os.path.join(os.path.abspath("."), self.config_file)) as f:
-                self.config = yaml.safe_load(f)
-                self.load_config(self.config)
-        except Exception as e:
-            logger.error(f"load {self.config_file} error, {e}!")
-
-        try:
-            with open(os.path.join(os.path.abspath("."), self.app_data_file)) as f:
-                self.app_data = yaml.safe_load(f)
-                self.load_app_data(self.app_data)
-        except Exception as e:
-            logger.error(f"load {self.app_data_file} error, {e}!")
-
     def reset(self):
         """reset Application"""
         # TODO: record total download task
@@ -90,8 +76,8 @@ class Application:
         self.web_port: int = 5000
         self.download_filter_dict: dict = {}
 
-    def load_config(self, _config: dict) -> bool:
-        """load config from str.
+    def assign_config(self, _config: dict) -> bool:
+        """assign config from str.
 
         Parameters
         ----------
@@ -185,8 +171,8 @@ class Application:
 
         return True
 
-    def load_app_data(self, app_data: dict) -> bool:
-        """load config from str.
+    def assign_app_data(self, app_data: dict) -> bool:
+        """Assign config from str.
 
         Parameters
         ----------
@@ -312,7 +298,9 @@ class Application:
 
         if chat_id in self.download_filter_dict:
             self.download_filter.set_meta_data(meta_data)
-            return not self.download_filter.exec(self.download_filter_dict[chat_id])
+            exec_res = not self.download_filter.exec(
+                self.download_filter_dict[chat_id])
+            return exec_res
 
         return False
 
@@ -327,7 +315,8 @@ class Application:
 
         # pylint: disable = W0201
         self.ids_to_retry = (
-            list(set(self.ids_to_retry) - set(self.downloaded_ids)) + self.failed_ids
+            list(set(self.ids_to_retry) -
+                 set(self.downloaded_ids)) + self.failed_ids
         )
 
         self.config["last_read_message_id"] = self.last_read_message_id
@@ -346,12 +335,24 @@ class Application:
         # self.app_data["already_download_ids"] = list(self.already_download_ids_set)
 
         if immediate:
-            with open(self.config_file, "w") as yaml_file:
-                yaml.dump(self.config, yaml_file, default_flow_style=False)
+            with open(self.config_file, "w", encoding="utf-8") as yaml_file:
+                yaml.dump(self.config, yaml_file, default_flow_style=False,
+                          encoding='utf-8', allow_unicode=True)
 
         if immediate:
-            with open(self.app_data_file, "w") as yaml_file:
-                yaml.dump(self.app_data, yaml_file, default_flow_style=False)
+            with open(self.app_data_file, "w", encoding="utf-8") as yaml_file:
+                yaml.dump(self.app_data, yaml_file, default_flow_style=False,
+                          encoding='utf-8', allow_unicode=True)
+
+    def load_config(self):
+        """Load user config"""
+        with open(os.path.join(os.path.abspath("."), self.config_file), encoding="utf-8") as f:
+            self.config = yaml.load(f.read(),Loader=yaml.FullLoader)
+            self.assign_config(self.config)
+
+        with open(os.path.join(os.path.abspath("."), self.app_data_file), encoding="utf-8") as f:
+            self.app_data = yaml.load(f.read(),Loader=yaml.FullLoader)
+            self.assign_app_data(self.app_data)
 
     def pre_run(self):
         """before run application do"""

--- a/module/app.py
+++ b/module/app.py
@@ -11,7 +11,6 @@ from module.filter import Filter
 from utils.format import replace_date_time
 from utils.meta_data import MetaData
 
-
 # pylint: disable = R0902
 
 
@@ -300,8 +299,7 @@ class Application:
 
         if chat_id in self.download_filter_dict:
             self.download_filter.set_meta_data(meta_data)
-            exec_res = not self.download_filter.exec(
-                self.download_filter_dict[chat_id])
+            exec_res = not self.download_filter.exec(self.download_filter_dict[chat_id])
             return exec_res
 
         return False
@@ -317,8 +315,7 @@ class Application:
 
         # pylint: disable = W0201
         self.ids_to_retry = (
-            list(set(self.ids_to_retry) -
-                 set(self.downloaded_ids)) + self.failed_ids
+            list(set(self.ids_to_retry) - set(self.downloaded_ids)) + self.failed_ids
         )
 
         self.config["last_read_message_id"] = self.last_read_message_id
@@ -338,22 +335,36 @@ class Application:
 
         if immediate:
             with open(self.config_file, "w", encoding="utf-8") as yaml_file:
-                yaml.dump(self.config, yaml_file, default_flow_style=False,
-                          encoding='utf-8', allow_unicode=True)
+                yaml.dump(
+                    self.config,
+                    yaml_file,
+                    default_flow_style=False,
+                    encoding="utf-8",
+                    allow_unicode=True,
+                )
 
         if immediate:
             with open(self.app_data_file, "w", encoding="utf-8") as yaml_file:
-                yaml.dump(self.app_data, yaml_file, default_flow_style=False,
-                          encoding='utf-8', allow_unicode=True)
+                yaml.dump(
+                    self.app_data,
+                    yaml_file,
+                    default_flow_style=False,
+                    encoding="utf-8",
+                    allow_unicode=True,
+                )
 
     def load_config(self):
         """Load user config"""
-        with open(os.path.join(os.path.abspath("."), self.config_file), encoding="utf-8") as f:
-            self.config = yaml.load(f.read(),Loader=yaml.FullLoader)
+        with open(
+            os.path.join(os.path.abspath("."), self.config_file), encoding="utf-8"
+        ) as f:
+            self.config = yaml.load(f.read(), Loader=yaml.FullLoader)
             self.assign_config(self.config)
 
-        with open(os.path.join(os.path.abspath("."), self.app_data_file), encoding="utf-8") as f:
-            self.app_data = yaml.load(f.read(),Loader=yaml.FullLoader)
+        with open(
+            os.path.join(os.path.abspath("."), self.app_data_file), encoding="utf-8"
+        ) as f:
+            self.app_data = yaml.load(f.read(), Loader=yaml.FullLoader)
             self.assign_app_data(self.app_data)
 
     def pre_run(self):

--- a/module/app.py
+++ b/module/app.py
@@ -4,7 +4,6 @@ import os
 from typing import List, Optional
 
 import yaml
-from loguru import logger
 
 from module.cloud_drive import CloudDrive, CloudDriveConfig
 from module.filter import Filter
@@ -43,10 +42,6 @@ class Application:
         self.application_name: str = application_name
         self.download_filter = Filter()
 
-        self.reset()
-
-    def reset(self):
-        """reset Application"""
         # TODO: record total download task
         self.total_download_task = 0
         self.downloaded_ids: list = []
@@ -76,6 +71,7 @@ class Application:
         self.web_host: str = "localhost"
         self.web_port: int = 5000
         self.download_filter_dict: dict = {}
+        self.ids_to_retry_dict: dict = {}
 
     def assign_config(self, _config: dict) -> bool:
         """assign config from str.
@@ -101,7 +97,7 @@ class Application:
         if _config.get("ids_to_retry"):
             self.ids_to_retry = _config["ids_to_retry"]
 
-        self.ids_to_retry_dict: dict = {}
+        self.ids_to_retry_dict = {}
         for it in self.ids_to_retry:
             self.ids_to_retry_dict[it] = True
 

--- a/module/filter.py
+++ b/module/filter.py
@@ -96,13 +96,13 @@ class BaseFilter(Parser):
 
     def t_STRING(self, t):
         r"'.*?'"
-        #r"'([^\\']+|\\'|\\\\)*'"
+        # r"'([^\\']+|\\'|\\\\)*'"
         t.value = t.value[1:-1]
         return t
 
     def t_RESTRING(self, t):
         r"r'.*?'"
-        #r"r'([^\\']+|\\'|\\\\)*'"
+        # r"r'([^\\']+|\\'|\\\\)*'"
         t.value = t.value[2:-1]
         return t
 
@@ -328,13 +328,16 @@ class Filter:
         self.filter.reset()
         self.filter.names = meta_data.data()
 
-    def set_debug(self, debug : bool):
+    def set_debug(self, debug: bool):
         """Set Filter Debug Model"""
         self.filter.debug = debug
 
-    def exec(self, filter_str: str) -> Any:
+    def exec(self, filter_str: str) -> bool:
         """Exec filter str"""
 
         if self.filter.names:
-            return self.filter.exec(filter_str)
+            res = self.filter.exec(filter_str)
+            if isinstance(res, bool):
+                return res
+            return False
         raise ValueError("meta data cannot be empty!")

--- a/module/filter.py
+++ b/module/filter.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from typing import Any
 
 from ply import lex, yacc
-from utils.format import get_byte_from_str
 
+from utils.format import get_byte_from_str
 from utils.meta_data import MetaData, NoneObj, ReString
 
 

--- a/module/pyrogram_extension.py
+++ b/module/pyrogram_extension.py
@@ -1,12 +1,17 @@
-
 import struct
 from io import BytesIO, StringIO
 from mimetypes import MimeTypes
 from typing import Optional
 
+from pyrogram.file_id import (
+    FILE_REFERENCE_FLAG,
+    PHOTO_TYPES,
+    WEB_LOCATION_FLAG,
+    FileType,
+    b64_decode,
+    rle_decode,
+)
 from pyrogram.mime_types import mime_types
-from pyrogram.file_id import FileType, PHOTO_TYPES, WEB_LOCATION_FLAG, FILE_REFERENCE_FLAG, rle_decode, b64_decode
-
 
 _mimetypes = MimeTypes()
 _mimetypes.readfp(StringIO(mime_types))
@@ -42,8 +47,7 @@ def _get_file_type(file_id: str):
     try:
         file_type = FileType(file_type)
     except ValueError as exc:
-        raise ValueError(
-            f"Unknown file_type {file_type} of file_id {file_id}") from exc
+        raise ValueError(f"Unknown file_type {file_type} of file_id {file_id}") from exc
 
     return file_type
 
@@ -54,7 +58,7 @@ def get_extension(file_id: str, mime_type: str) -> str:
     file_type = _get_file_type(file_id)
 
     guessed_extension = _guess_extension(mime_type)
-    
+
     if file_type in PHOTO_TYPES:
         extension = ".jpg"
     elif file_type == FileType.VOICE:

--- a/module/pyrogram_extension.py
+++ b/module/pyrogram_extension.py
@@ -1,3 +1,5 @@
+"""Pyrogram ext"""
+
 import struct
 from io import BytesIO, StringIO
 from mimetypes import MimeTypes

--- a/module/pyrogram_extension.py
+++ b/module/pyrogram_extension.py
@@ -1,0 +1,73 @@
+
+import struct
+from io import BytesIO, StringIO
+from mimetypes import MimeTypes
+from typing import Optional
+
+from pyrogram.mime_types import mime_types
+from pyrogram.file_id import FileType, PHOTO_TYPES, WEB_LOCATION_FLAG, FILE_REFERENCE_FLAG, rle_decode, b64_decode
+
+
+_mimetypes = MimeTypes()
+_mimetypes.readfp(StringIO(mime_types))
+
+
+def _guess_mime_type(filename: str) -> Optional[str]:
+    """Guess mime type"""
+    return _mimetypes.guess_type(filename)[0]
+
+
+def _guess_extension(mime_type: str) -> Optional[str]:
+    """Guess extension"""
+    return _mimetypes.guess_extension(mime_type)
+
+
+def _get_file_type(file_id: str):
+    """Get file type"""
+    decoded = rle_decode(b64_decode(file_id))
+
+    # File id versioning. Major versions lower than 4 don't have a minor version
+    major = decoded[-1]
+
+    if major < 4:
+        buffer = BytesIO(decoded[:-1])
+    else:
+        buffer = BytesIO(decoded[:-2])
+
+    file_type, _ = struct.unpack("<ii", buffer.read(8))
+
+    file_type &= ~WEB_LOCATION_FLAG
+    file_type &= ~FILE_REFERENCE_FLAG
+
+    try:
+        file_type = FileType(file_type)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unknown file_type {file_type} of file_id {file_id}") from exc
+
+    return file_type
+
+
+def get_extension(file_id: str, mime_type: str) -> str:
+    """Get extension"""
+
+    file_type = _get_file_type(file_id)
+
+    guessed_extension = _guess_extension(mime_type)
+    
+    if file_type in PHOTO_TYPES:
+        extension = ".jpg"
+    elif file_type == FileType.VOICE:
+        extension = guessed_extension or ".ogg"
+    elif file_type in (FileType.VIDEO, FileType.ANIMATION, FileType.VIDEO_NOTE):
+        extension = guessed_extension or ".mp4"
+    elif file_type == FileType.DOCUMENT:
+        extension = guessed_extension or ".zip"
+    elif file_type == FileType.STICKER:
+        extension = guessed_extension or ".webp"
+    elif file_type == FileType.AUDIO:
+        extension = guessed_extension or ".mp3"
+    else:
+        extension = ".unknown"
+
+    return extension

--- a/test_user_filter.py
+++ b/test_user_filter.py
@@ -1,0 +1,48 @@
+
+
+from datetime import datetime
+from tests.test_common import MockMessage, MockVideo
+from module.filter import Filter, MetaData
+from utils.format import replace_date_time
+
+
+# custom
+vec_filter = [
+    "file_size > 1KB && file_size <= 10MB",
+    "(file_size > 1KB && file_size <= 10MB) and caption == r'.*#我的最爱.*'",
+    "(file_size > 1KB && file_size <= 10MB) and caption == r'.*三体.*'",
+    "(file_size > 1KB && file_size <= 10MB) and caption != r'.*女主播.*'",
+    # \. eq string .
+    "(file_size > 1KB && file_size <= 10MB) and caption != r'test\.mp4'",
+    "(file_size > 1KB && file_size <= 10MB) and file_name == r'test\.mp4'",
+    "(file_size > 1KB && file_size <= 10MB) and file_name != r'test\-mp4'",
+]
+
+meta = MetaData()
+
+message = MockMessage(
+    id=5,
+    media=True,
+    date=datetime(2022, 8, 5, 14, 35, 12),
+    chat_title="test2",
+    caption="#书籍 #我的最爱 #三体",
+    video=MockVideo(
+        mime_type="video/mp4",
+        file_size=1024 * 1024 * 10,
+        file_name="test.mp4",
+        width=1920,
+        height=1080,
+        duration=35,
+    ),
+)
+
+meta.get_meta_data(message)
+
+download_filter = Filter()
+
+download_filter.set_meta_data(meta)
+
+
+for filter_str in vec_filter:
+    tmp_filter_str = replace_date_time(filter_str)
+    print(f"{filter_str} {download_filter.exec(tmp_filter_str)}")

--- a/test_user_filter.py
+++ b/test_user_filter.py
@@ -1,8 +1,7 @@
-
-
 from datetime import datetime
-from tests.test_common import MockMessage, MockVideo
+
 from module.filter import Filter, MetaData
+from tests.test_common import MockMessage, MockVideo
 from utils.format import replace_date_time
 
 # enter you want to test

--- a/test_user_filter.py
+++ b/test_user_filter.py
@@ -5,27 +5,20 @@ from tests.test_common import MockMessage, MockVideo
 from module.filter import Filter, MetaData
 from utils.format import replace_date_time
 
-
-# custom
+# enter you want to test
 vec_filter = [
     "file_size > 1KB && file_size <= 10MB",
-    "(file_size > 1KB && file_size <= 10MB) and caption == r'.*#我的最爱.*'",
-    "(file_size > 1KB && file_size <= 10MB) and caption == r'.*三体.*'",
-    "(file_size > 1KB && file_size <= 10MB) and caption != r'.*女主播.*'",
-    # \. eq string .
-    "(file_size > 1KB && file_size <= 10MB) and caption != r'test\.mp4'",
-    "(file_size > 1KB && file_size <= 10MB) and file_name == r'test\.mp4'",
-    "(file_size > 1KB && file_size <= 10MB) and file_name != r'test\-mp4'",
 ]
 
 meta = MetaData()
 
+# enter you want to test
 message = MockMessage(
     id=5,
     media=True,
     date=datetime(2022, 8, 5, 14, 35, 12),
     chat_title="test2",
-    caption="#书籍 #我的最爱 #三体",
+    caption="enter you want to test",
     video=MockVideo(
         mime_type="video/mp4",
         file_size=1024 * 1024 * 10,

--- a/tests/module/test_app.py
+++ b/tests/module/test_app.py
@@ -5,8 +5,8 @@ import sys
 import unittest
 from unittest import mock
 
-from module.app import Application
 import module.app
+from module.app import Application
 
 sys.path.append("..")  # Adds higher directory to python modules path.
 
@@ -43,4 +43,4 @@ class AppTestCase(unittest.TestCase):
         app.config_file = "config_test.yaml"
         app.app_data_file = "data_test.yaml"
         app.update_config()
-        mock_open.assert_called_with("data_test.yaml", "w", encoding='utf-8')
+        mock_open.assert_called_with("data_test.yaml", "w", encoding="utf-8")

--- a/tests/module/test_app.py
+++ b/tests/module/test_app.py
@@ -6,6 +6,7 @@ import unittest
 from unittest import mock
 
 from module.app import Application
+import module.app
 
 sys.path.append("..")  # Adds higher directory to python modules path.
 

--- a/tests/test_app/test_app.py
+++ b/tests/test_app/test_app.py
@@ -42,7 +42,4 @@ class AppTestCase(unittest.TestCase):
         app.config_file = "config_test.yaml"
         app.app_data_file = "data_test.yaml"
         app.update_config()
-        mock_open.assert_called_with("data_test.yaml", "w")
-        mock_yaml.dump.assert_called_with(
-            app.config, mock.ANY, default_flow_style=False
-        )
+        mock_open.assert_called_with("data_test.yaml", "w", encoding='utf-8')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -38,6 +38,7 @@ class MockMessage:
         if kwargs.get("date") != None:
             self.date = kwargs["date"]
 
+
 class MockAudio:
     def __init__(self, **kwargs):
         self.file_name = kwargs["file_name"]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -38,11 +38,11 @@ class MockMessage:
         if kwargs.get("date") != None:
             self.date = kwargs["date"]
 
-
 class MockAudio:
     def __init__(self, **kwargs):
         self.file_name = kwargs["file_name"]
         self.mime_type = kwargs["mime_type"]
+        self.file_id = "AUDIO"
         if kwargs.get("file_size"):
             self.file_size = kwargs["file_size"]
         else:
@@ -53,6 +53,7 @@ class MockDocument:
     def __init__(self, **kwargs):
         self.file_name = kwargs["file_name"]
         self.mime_type = kwargs["mime_type"]
+        self.file_id = "DOCUMENT"
         if kwargs.get("file_size"):
             self.file_size = kwargs["file_size"]
         else:
@@ -63,6 +64,7 @@ class MockPhoto:
     def __init__(self, **kwargs):
         self.date = kwargs["date"]
         self.file_unique_id = kwargs["file_unique_id"]
+        self.file_id = "PHOTO"
         if kwargs.get("file_size"):
             self.file_size = kwargs["file_size"]
         else:
@@ -73,6 +75,7 @@ class MockVoice:
     def __init__(self, **kwargs):
         self.mime_type = kwargs["mime_type"]
         self.date = kwargs["date"]
+        self.file_id = "VOICE"
         if kwargs.get("file_size"):
             self.file_size = kwargs["file_size"]
         else:
@@ -83,6 +86,7 @@ class MockVideo:
     def __init__(self, **kwargs):
         self.file_name = kwargs.get("file_name")
         self.mime_type = kwargs["mime_type"]
+        self.file_id = "VIDEO"
         if kwargs.get("file_size"):
             self.file_size = kwargs["file_size"]
         else:
@@ -107,4 +111,5 @@ class MockVideo:
 class MockVideoNote:
     def __init__(self, **kwargs):
         self.mime_type = kwargs["mime_type"]
+        self.file_id = "VIDEO_NOTE"
         self.date = kwargs["date"]

--- a/tests/test_media_downloader.py
+++ b/tests/test_media_downloader.py
@@ -72,7 +72,7 @@ def rest_app(conf: dict):
     app.reset()
     app.config_file = "config_test.yaml"
     app.app_data_file = "data_test.yaml"
-    app.load_config(conf)
+    app.assign_config(conf)
 
 
 def platform_generic_path(_path: str) -> str:
@@ -845,7 +845,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
         app.failed_ids.append(4)
 
         try:
-            exec_main()
+            main()
         except:
             pass
 

--- a/tests/test_media_downloader.py
+++ b/tests/test_media_downloader.py
@@ -2,6 +2,7 @@
 import asyncio
 import os
 import platform
+from typing import List
 import unittest
 from datetime import datetime
 
@@ -20,6 +21,7 @@ from media_downloader import (
     main,
     process_messages,
 )
+from module.cloud_drive import CloudDriveConfig
 
 from .test_common import (
     Chat,
@@ -70,7 +72,34 @@ def os_get_file_size(file: str) -> int:
 
 
 def rest_app(conf: dict):
-    app.reset()
+    app.total_download_task = 0
+    app.downloaded_ids: list = []
+    # app.already_download_ids_set = set()
+    app.failed_ids: list = []
+    app.disable_syslog: list = []
+    app.save_path = os.path.abspath(".")
+    app.ids_to_retry: list = []
+    app.api_id: str = ""
+    app.api_hash: str = ""
+    app.chat_id: str = ""
+    app.media_types: List[str] = []
+    app.file_formats: dict = {}
+    app.proxy: dict = {}
+    app.last_read_message_id = 0
+    app.restart_program = False
+    app.config: dict = {}
+    app.app_data: dict = {}
+    app.file_path_prefix: List[str] = ["chat_title", "media_datetime"]
+    app.file_name_prefix: List[str] = ["message_id", "file_name"]
+    app.file_name_prefix_split: str = " - "
+    app.log_file_path = os.path.join(os.path.abspath("."), "log")
+    app.cloud_drive_config = CloudDriveConfig()
+    app.hide_file_name = False
+    app.caption_name_dict: dict = {}
+    app.max_concurrent_transmissions: int = 1
+    app.web_host: str = "localhost"
+    app.web_port: int = 5000
+    app.download_filter_dict: dict = {}
     app.config_file = "config_test.yaml"
     app.app_data_file = "data_test.yaml"
     app.assign_config(conf)

--- a/tests/test_media_downloader.py
+++ b/tests/test_media_downloader.py
@@ -2,9 +2,9 @@
 import asyncio
 import os
 import platform
-from typing import List
 import unittest
 from datetime import datetime
+from typing import List
 
 import mock
 import pyrogram

--- a/tests/test_media_downloader.py
+++ b/tests/test_media_downloader.py
@@ -4,9 +4,10 @@ import os
 import platform
 import unittest
 from datetime import datetime
-from pyrogram.file_id import FileType, PHOTO_TYPES
+
 import mock
 import pyrogram
+from pyrogram.file_id import PHOTO_TYPES, FileType
 
 from media_downloader import (
     _can_download,
@@ -362,8 +363,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
         )
         self.assertEqual(
             (
-                platform_generic_path(
-                    "/root/project/test2/2019_08/2 - ADAVKJYIFV.jpg"),
+                platform_generic_path("/root/project/test2/2019_08/2 - ADAVKJYIFV.jpg"),
                 None,
             ),
             result,
@@ -408,8 +408,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
         )
         self.assertEqual(
             (
-                platform_generic_path(
-                    "/root/project/test2/0/3 - sample_document.pdf"),
+                platform_generic_path("/root/project/test2/0/3 - sample_document.pdf"),
                 "pdf",
             ),
             result,
@@ -504,8 +503,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
         )
         self.assertEqual(
             (
-                platform_generic_path(
-                    "/root/project/test2/2022_08/5 - test.mp4"),
+                platform_generic_path("/root/project/test2/2022_08/5 - test.mp4"),
                 "mp4",
             ),
             result,
@@ -529,8 +527,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
         print(app.chat_id)
         self.assertEqual(
             (
-                platform_generic_path(
-                    "/root/project/8654123/2022_08/5 - test.mp4"),
+                platform_generic_path("/root/project/8654123/2022_08/5 - test.mp4"),
                 "mp4",
             ),
             result,
@@ -699,8 +696,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
             )
         )
         self.assertEqual(420, result)
-        mock_logger.warning.assert_called_with(
-            "Message[{}]: FlowWait {}", 420, 420)
+        mock_logger.warning.assert_called_with("Message[{}]: FlowWait {}", 420, 420)
         self.assertEqual(app.failed_ids.count(420), 1)
 
         # Test other Exception
@@ -930,8 +926,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
     @mock.patch("media_downloader.logger")
     def test_check_config(self, mock_logger):
         _check_config()
-        mock_logger.error.assert_called_with(
-            "load config error: error load config")
+        mock_logger.error.assert_called_with("load config error: error load config")
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/utils/test_filter.py
+++ b/tests/utils/test_filter.py
@@ -37,7 +37,7 @@ class FilterTestCase(unittest.TestCase):
             media=True,
             date=datetime(2022, 8, 5, 14, 35, 12),
             chat_title="test2",
-            caption="",
+            caption=None,
             video=MockVideo(
                 mime_type="video/mp4",
                 file_size=1024 * 1024 * 10,
@@ -61,33 +61,49 @@ class FilterTestCase(unittest.TestCase):
 
         download_filter.set_meta_data(meta)
 
-        self.assertEqual(filter_exec(download_filter, "media_file_size == 1"), False)
-        self.assertEqual(filter_exec(download_filter, "media_file_size > 1024"), True)
+        self.assertEqual(filter_exec(
+            download_filter, "media_file_size == 1"), False)
+        self.assertEqual(filter_exec(
+            download_filter, "media_file_size > 1024"), True)
 
         # str
         self.assertEqual(
             filter_exec(download_filter, "media_file_name == 'test.mp4'"), True
         )
         self.assertEqual(
-            filter_exec(download_filter, "media_file_name == 'test2.mp4'"), False
+            filter_exec(download_filter,
+                        "media_file_name == 'test2.mp4'"), False
         )
         # re str
         self.assertEqual(
-            filter_exec(download_filter, "media_file_name == r'test.*mp4'"), True
+            filter_exec(download_filter,
+                        "media_file_name == r'test.*mp4'"), True
+        )
+
+        self.assertEqual(
+            filter_exec(download_filter,
+                        "media_file_name == r'test\.*mp4'"), True
+        )
+
+        self.assertEqual(
+            filter_exec(download_filter,
+                        "media_file_name == r'test2.*mp4'"), False
+        )
+
+        self.assertEqual(
+            filter_exec(download_filter,
+                        "media_file_name != r'test2.*mp4'"), True
         )
         self.assertEqual(
-            filter_exec(download_filter, "media_file_name == r'test2.*mp4'"), False
-        )
-        self.assertEqual(
-            filter_exec(download_filter, "media_file_name != r'test2.*mp4'"), True
-        )
-        self.assertEqual(
-            filter_exec(download_filter, "media_file_name != r'test2.*mp4'"), True
+            filter_exec(download_filter,
+                        "media_file_name != r'test2.*mp4'"), True
         )
 
         # int
-        self.assertEqual(filter_exec(download_filter, "media_duration > 60"), False)
-        self.assertEqual(filter_exec(download_filter, "media_duration <= 60"), True)
+        self.assertEqual(filter_exec(
+            download_filter, "media_duration > 60"), False)
+        self.assertEqual(filter_exec(
+            download_filter, "media_duration <= 60"), True)
         self.assertEqual(
             filter_exec(
                 download_filter, "media_width >= 1920 and media_height >= 1080"
@@ -95,7 +111,8 @@ class FilterTestCase(unittest.TestCase):
             True,
         )
         self.assertEqual(
-            filter_exec(download_filter, "media_width >= 2560 && media_height >= 1440"),
+            filter_exec(download_filter,
+                        "media_width >= 2560 && media_height >= 1440"),
             False,
         )
         self.assertEqual(
@@ -176,4 +193,100 @@ class FilterTestCase(unittest.TestCase):
                 "message_date >= 2022.03.04 && message_date <= 2022.08.06 && not_exist == True",
             ),
             True,
+        )
+
+        download_filter.set_debug(True)
+
+        # test file_size
+        self.assertEqual(
+            filter_exec(
+                download_filter,
+                "file_size >= 10MB"
+            ), True
+        )
+
+        self.assertEqual(
+            filter_exec(
+                download_filter,
+                "file_size >= 11MB"
+            ), False
+        )
+
+        self.assertEqual(
+            filter_exec(
+                download_filter,
+                "file_size >= 11GB"
+            ), False
+        )
+
+        self.assertEqual(
+            filter_exec(
+                download_filter,
+                "file_size <= 11GB"
+            ), True
+        )
+
+        self.assertEqual(
+            filter_exec(
+                download_filter,
+                "1024 * 1024 * 1024 * 11 == 11GB"
+            ), True
+        )
+
+    def test_str_obj(self):
+        download_filter = Filter()
+        self.assertRaises(ValueError, filter_exec, download_filter, "213")
+
+        meta = MetaData()
+
+        message = MockMessage(
+            id=5,
+            media=True,
+            date=datetime(2022, 8, 5, 14, 35, 12),
+            chat_title="test2",
+            caption='#中文最吊 #哈啰',
+            video=MockVideo(
+                mime_type="video/mp4",
+                file_size=1024 * 1024 * 10,
+                file_name="test.mp4",
+                width=1920,
+                height=1080,
+                duration=35,
+            ),
+        )
+
+        meta.get_meta_data(message)
+
+        self.assertEqual(meta.message_id, 5)
+        self.assertEqual(meta.message_date, datetime(2022, 8, 5, 14, 35, 12))
+        self.assertEqual(meta.message_caption, '#中文最吊 #哈啰')
+        self.assertEqual(meta.media_file_size, 1024 * 1024 * 10)
+        self.assertEqual(meta.media_width, 1920)
+        self.assertEqual(meta.media_height, 1080)
+        self.assertEqual(meta.media_file_name, "test.mp4")
+        self.assertEqual(meta.media_duration, 35)
+
+        download_filter.set_meta_data(meta)
+        download_filter.set_debug(True)
+
+        # test caption
+        self.assertEqual(
+            filter_exec(
+                download_filter,
+                "caption == r'.*#test.*'"
+            ), False
+        )
+
+        self.assertEqual(
+            filter_exec(
+                download_filter,
+                "caption == r'.*#中文.*'"
+            ), True
+        )
+
+        self.assertEqual(
+            filter_exec(
+                download_filter,
+                "caption == r'.*#中文啊.*'"
+            ), False
         )

--- a/tests/utils/test_filter.py
+++ b/tests/utils/test_filter.py
@@ -61,49 +61,39 @@ class FilterTestCase(unittest.TestCase):
 
         download_filter.set_meta_data(meta)
 
-        self.assertEqual(filter_exec(
-            download_filter, "media_file_size == 1"), False)
-        self.assertEqual(filter_exec(
-            download_filter, "media_file_size > 1024"), True)
+        self.assertEqual(filter_exec(download_filter, "media_file_size == 1"), False)
+        self.assertEqual(filter_exec(download_filter, "media_file_size > 1024"), True)
 
         # str
         self.assertEqual(
             filter_exec(download_filter, "media_file_name == 'test.mp4'"), True
         )
         self.assertEqual(
-            filter_exec(download_filter,
-                        "media_file_name == 'test2.mp4'"), False
+            filter_exec(download_filter, "media_file_name == 'test2.mp4'"), False
         )
         # re str
         self.assertEqual(
-            filter_exec(download_filter,
-                        "media_file_name == r'test.*mp4'"), True
+            filter_exec(download_filter, "media_file_name == r'test.*mp4'"), True
         )
 
         self.assertEqual(
-            filter_exec(download_filter,
-                        "media_file_name == r'test\.*mp4'"), True
+            filter_exec(download_filter, "media_file_name == r'test\.*mp4'"), True
         )
 
         self.assertEqual(
-            filter_exec(download_filter,
-                        "media_file_name == r'test2.*mp4'"), False
+            filter_exec(download_filter, "media_file_name == r'test2.*mp4'"), False
         )
 
         self.assertEqual(
-            filter_exec(download_filter,
-                        "media_file_name != r'test2.*mp4'"), True
+            filter_exec(download_filter, "media_file_name != r'test2.*mp4'"), True
         )
         self.assertEqual(
-            filter_exec(download_filter,
-                        "media_file_name != r'test2.*mp4'"), True
+            filter_exec(download_filter, "media_file_name != r'test2.*mp4'"), True
         )
 
         # int
-        self.assertEqual(filter_exec(
-            download_filter, "media_duration > 60"), False)
-        self.assertEqual(filter_exec(
-            download_filter, "media_duration <= 60"), True)
+        self.assertEqual(filter_exec(download_filter, "media_duration > 60"), False)
+        self.assertEqual(filter_exec(download_filter, "media_duration <= 60"), True)
         self.assertEqual(
             filter_exec(
                 download_filter, "media_width >= 1920 and media_height >= 1080"
@@ -111,8 +101,7 @@ class FilterTestCase(unittest.TestCase):
             True,
         )
         self.assertEqual(
-            filter_exec(download_filter,
-                        "media_width >= 2560 && media_height >= 1440"),
+            filter_exec(download_filter, "media_width >= 2560 && media_height >= 1440"),
             False,
         )
         self.assertEqual(
@@ -198,39 +187,16 @@ class FilterTestCase(unittest.TestCase):
         download_filter.set_debug(True)
 
         # test file_size
-        self.assertEqual(
-            filter_exec(
-                download_filter,
-                "file_size >= 10MB"
-            ), True
-        )
+        self.assertEqual(filter_exec(download_filter, "file_size >= 10MB"), True)
+
+        self.assertEqual(filter_exec(download_filter, "file_size >= 11MB"), False)
+
+        self.assertEqual(filter_exec(download_filter, "file_size >= 11GB"), False)
+
+        self.assertEqual(filter_exec(download_filter, "file_size <= 11GB"), True)
 
         self.assertEqual(
-            filter_exec(
-                download_filter,
-                "file_size >= 11MB"
-            ), False
-        )
-
-        self.assertEqual(
-            filter_exec(
-                download_filter,
-                "file_size >= 11GB"
-            ), False
-        )
-
-        self.assertEqual(
-            filter_exec(
-                download_filter,
-                "file_size <= 11GB"
-            ), True
-        )
-
-        self.assertEqual(
-            filter_exec(
-                download_filter,
-                "1024 * 1024 * 1024 * 11 == 11GB"
-            ), True
+            filter_exec(download_filter, "1024 * 1024 * 1024 * 11 == 11GB"), True
         )
 
     def test_str_obj(self):
@@ -244,7 +210,7 @@ class FilterTestCase(unittest.TestCase):
             media=True,
             date=datetime(2022, 8, 5, 14, 35, 12),
             chat_title="test2",
-            caption='#中文最吊 #哈啰',
+            caption="#中文最吊 #哈啰",
             video=MockVideo(
                 mime_type="video/mp4",
                 file_size=1024 * 1024 * 10,
@@ -259,7 +225,7 @@ class FilterTestCase(unittest.TestCase):
 
         self.assertEqual(meta.message_id, 5)
         self.assertEqual(meta.message_date, datetime(2022, 8, 5, 14, 35, 12))
-        self.assertEqual(meta.message_caption, '#中文最吊 #哈啰')
+        self.assertEqual(meta.message_caption, "#中文最吊 #哈啰")
         self.assertEqual(meta.media_file_size, 1024 * 1024 * 10)
         self.assertEqual(meta.media_width, 1920)
         self.assertEqual(meta.media_height, 1080)
@@ -270,23 +236,8 @@ class FilterTestCase(unittest.TestCase):
         download_filter.set_debug(True)
 
         # test caption
-        self.assertEqual(
-            filter_exec(
-                download_filter,
-                "caption == r'.*#test.*'"
-            ), False
-        )
+        self.assertEqual(filter_exec(download_filter, "caption == r'.*#test.*'"), False)
 
-        self.assertEqual(
-            filter_exec(
-                download_filter,
-                "caption == r'.*#中文.*'"
-            ), True
-        )
+        self.assertEqual(filter_exec(download_filter, "caption == r'.*#中文.*'"), True)
 
-        self.assertEqual(
-            filter_exec(
-                download_filter,
-                "caption == r'.*#中文啊.*'"
-            ), False
-        )
+        self.assertEqual(filter_exec(download_filter, "caption == r'.*#中文啊.*'"), False)

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -2,7 +2,7 @@
 import sys
 import unittest
 
-from utils.format import format_byte, replace_date_time
+from utils.format import format_byte, get_byte_from_str, replace_date_time
 
 sys.path.append("..")  # Adds higher directory to python modules path.
 
@@ -79,3 +79,27 @@ class FormatTestCase(unittest.TestCase):
             replace_date_time("xasd as 2020.03 21321fszv"),
             "xasd as 2020-03-01 00:00:00 21321fszv",
         )
+
+    def test_get_byte_from_str(self):
+        # B
+        self.assertEqual(get_byte_from_str("2B"), 2)
+        # KB
+        self.assertEqual(get_byte_from_str("2KB"), 2 * 1024)
+        self.assertEqual(get_byte_from_str("1024KB"), 1024 * 1024)
+        self.assertEqual(get_byte_from_str("2024KB"), 2024 * 1024)
+        self.assertEqual(get_byte_from_str("4000KB"), 4000 * 1024)
+
+        # MB
+        self.assertEqual(get_byte_from_str("2MB"), 2 * 1024 * 1024)
+        self.assertEqual(get_byte_from_str("1024MB"), 1024 * 1024 * 1024)
+
+        #GB
+        self.assertEqual(get_byte_from_str("2GB"), 2 * 1024 * 1024 * 1024)
+
+        #TB
+        self.assertEqual(get_byte_from_str("2TB"), 2 * 1024 * 1024 * 1024 * 1024)
+        self.assertEqual(get_byte_from_str("1024TB"), 1024 * 1024 * 1024 * 1024 * 1024)
+
+        # more str
+        self.assertEqual(get_byte_from_str("2BW"), 2)
+        self.assertEqual(get_byte_from_str("2WBW"), None)

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -123,5 +123,5 @@ class FormatTestCase(unittest.TestCase):
             self.assertEqual(truncate_filename("D:\\MyDisk\\github\\wwww_我我我我.mp4", 14),
                          "D:\\MyDisk\\github\\wwww_我.mp4")
         else:
-            self.assertEqual(truncate_filename("/hom/MyDisk/github/wwww_wwww.mp4", 8),
+            self.assertEqual(truncate_filename("/home/MyDisk/github/wwww_wwww.mp4", 8),
                          "/home/MyDisk/github/wwww.mp4")

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -2,7 +2,12 @@
 import sys
 import unittest
 
-from utils.format import truncate_filename, format_byte, get_byte_from_str, replace_date_time
+from utils.format import (
+    format_byte,
+    get_byte_from_str,
+    replace_date_time,
+    truncate_filename,
+)
 
 sys.path.append("..")  # Adds higher directory to python modules path.
 
@@ -62,8 +67,7 @@ class FormatTestCase(unittest.TestCase):
 
         # more space
         self.assertEqual(
-            replace_date_time(
-                "xxxxx 2020.03.08 2020.03.09      14:51 xxxxxxxxx"),
+            replace_date_time("xxxxx 2020.03.08 2020.03.09      14:51 xxxxxxxxx"),
             "xxxxx 2020-03-08 00:00:00 2020-03-09 14:51:00 xxxxxxxxx",
         )
 
@@ -98,10 +102,8 @@ class FormatTestCase(unittest.TestCase):
         self.assertEqual(get_byte_from_str("2GB"), 2 * 1024 * 1024 * 1024)
 
         # TB
-        self.assertEqual(get_byte_from_str("2TB"),
-                         2 * 1024 * 1024 * 1024 * 1024)
-        self.assertEqual(get_byte_from_str("1024TB"),
-                         1024 * 1024 * 1024 * 1024 * 1024)
+        self.assertEqual(get_byte_from_str("2TB"), 2 * 1024 * 1024 * 1024 * 1024)
+        self.assertEqual(get_byte_from_str("1024TB"), 1024 * 1024 * 1024 * 1024 * 1024)
 
         # more str
         self.assertEqual(get_byte_from_str("2BW"), 2)
@@ -109,19 +111,25 @@ class FormatTestCase(unittest.TestCase):
 
     def test_truncate_filename(self):
 
-        self.assertEqual(truncate_filename("wwww wwww", 8),
-                         "wwww www")
+        self.assertEqual(truncate_filename("wwww wwww", 8), "wwww www")
 
-        self.assertEqual(truncate_filename("wwww 我我我", 8),
-                         "wwww 我")
+        self.assertEqual(truncate_filename("wwww 我我我", 8), "wwww 我")
 
         if sys.platform == "win32":
-            self.assertEqual(truncate_filename("D:\\MyDisk\\github\\wwww_wwww.mp4", 8),
-                         "D:\\MyDisk\\github\\wwww.mp4")
-            self.assertEqual(truncate_filename("D:\\MyDisk\\github\\wwww_我我我我.mp4", 12),
-                         "D:\\MyDisk\\github\\wwww_我.mp4")
-            self.assertEqual(truncate_filename("D:\\MyDisk\\github\\wwww_我我我我.mp4", 14),
-                         "D:\\MyDisk\\github\\wwww_我.mp4")
+            self.assertEqual(
+                truncate_filename("D:\\MyDisk\\github\\wwww_wwww.mp4", 8),
+                "D:\\MyDisk\\github\\wwww.mp4",
+            )
+            self.assertEqual(
+                truncate_filename("D:\\MyDisk\\github\\wwww_我我我我.mp4", 12),
+                "D:\\MyDisk\\github\\wwww_我.mp4",
+            )
+            self.assertEqual(
+                truncate_filename("D:\\MyDisk\\github\\wwww_我我我我.mp4", 14),
+                "D:\\MyDisk\\github\\wwww_我.mp4",
+            )
         else:
-            self.assertEqual(truncate_filename("/home/MyDisk/github/wwww_wwww.mp4", 8),
-                         "/home/MyDisk/github/wwww.mp4")
+            self.assertEqual(
+                truncate_filename("/home/MyDisk/github/wwww_wwww.mp4", 8),
+                "/home/MyDisk/github/wwww.mp4",
+            )

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -2,7 +2,7 @@
 import sys
 import unittest
 
-from utils.format import format_byte, get_byte_from_str, replace_date_time
+from utils.format import truncate_filename, format_byte, get_byte_from_str, replace_date_time
 
 sys.path.append("..")  # Adds higher directory to python modules path.
 
@@ -62,7 +62,8 @@ class FormatTestCase(unittest.TestCase):
 
         # more space
         self.assertEqual(
-            replace_date_time("xxxxx 2020.03.08 2020.03.09      14:51 xxxxxxxxx"),
+            replace_date_time(
+                "xxxxx 2020.03.08 2020.03.09      14:51 xxxxxxxxx"),
             "xxxxx 2020-03-08 00:00:00 2020-03-09 14:51:00 xxxxxxxxx",
         )
 
@@ -93,13 +94,34 @@ class FormatTestCase(unittest.TestCase):
         self.assertEqual(get_byte_from_str("2MB"), 2 * 1024 * 1024)
         self.assertEqual(get_byte_from_str("1024MB"), 1024 * 1024 * 1024)
 
-        #GB
+        # GB
         self.assertEqual(get_byte_from_str("2GB"), 2 * 1024 * 1024 * 1024)
 
-        #TB
-        self.assertEqual(get_byte_from_str("2TB"), 2 * 1024 * 1024 * 1024 * 1024)
-        self.assertEqual(get_byte_from_str("1024TB"), 1024 * 1024 * 1024 * 1024 * 1024)
+        # TB
+        self.assertEqual(get_byte_from_str("2TB"),
+                         2 * 1024 * 1024 * 1024 * 1024)
+        self.assertEqual(get_byte_from_str("1024TB"),
+                         1024 * 1024 * 1024 * 1024 * 1024)
 
         # more str
         self.assertEqual(get_byte_from_str("2BW"), 2)
         self.assertEqual(get_byte_from_str("2WBW"), None)
+
+    def test_truncate_filename(self):
+
+        self.assertEqual(truncate_filename("wwww wwww", 8),
+                         "wwww www")
+
+        self.assertEqual(truncate_filename("wwww 我我我", 8),
+                         "wwww 我")
+
+        if sys.platform == "win32":
+            self.assertEqual(truncate_filename("D:\\MyDisk\\github\\wwww_wwww.mp4", 8),
+                         "D:\\MyDisk\\github\\wwww.mp4")
+            self.assertEqual(truncate_filename("D:\\MyDisk\\github\\wwww_我我我我.mp4", 12),
+                         "D:\\MyDisk\\github\\wwww_我.mp4")
+            self.assertEqual(truncate_filename("D:\\MyDisk\\github\\wwww_我我我我.mp4", 14),
+                         "D:\\MyDisk\\github\\wwww_我.mp4")
+        else:
+            self.assertEqual(truncate_filename("/hom/MyDisk/github/wwww_wwww.mp4", 8),
+                         "/home/MyDisk/github/wwww.mp4")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,5 @@
 """Init namespace"""
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 __license__ = "MIT License"
 __copyright__ = "Copyright (C) 2023 tangyoha <https://github.com/tangyoha>"

--- a/utils/format.py
+++ b/utils/format.py
@@ -99,12 +99,13 @@ def get_date_time(text: str, fmt: str) -> SearchDateTimeResult:
         if search_res:
             time_str = search_res.group(0)
             res.value = datetime.strptime(
-                time_str.replace("/", "-").replace(".", "-").strip(), format_list[i]
+                time_str.replace("/", "-").replace(".",
+                                                   "-").strip(), format_list[i]
             ).strftime(fmt)
             if search_res.start() != 0:
-                res.left_str = search_text[0 : search_res.start()]
+                res.left_str = search_text[0: search_res.start()]
             if search_res.end() + 1 <= len(search_text):
-                res.right_str = search_text[search_res.end() :]
+                res.right_str = search_text[search_res.end():]
             res.match = True
             return res
 
@@ -121,6 +122,7 @@ def replace_date_time(text: str, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
 
     fmt: str
         the right datetime format
+
     Returns
     -------
     str
@@ -138,3 +140,35 @@ def replace_date_time(text: str, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
         res_str += replace_date_time(res.right_str)
 
     return res_str
+
+
+_BYTE_UNIT = ["B", "KB", "MB", "GB", "TB"]
+
+
+def get_byte_from_str(byte_str: str) -> int:
+    """Get byte from str
+
+    Parameters
+    ----------
+    byte_str: str
+        Include byte str
+
+    Returns
+    -------
+    int
+        Byte
+    """
+    search_res = re.match(r"(\d{1,})(B|KB|MB|GB|TB)", byte_str)
+    if search_res:
+        unit_str = search_res.group(2)
+        unit: int = 1
+        for it in _BYTE_UNIT:
+            if it == unit_str:
+                break
+            unit *= 1024
+        else:
+            raise ValueError(f"{byte_str} not support")
+
+        return int(search_res.group(1)) * unit
+
+    return None

--- a/utils/format.py
+++ b/utils/format.py
@@ -5,6 +5,7 @@ import os
 import re
 import unicodedata
 from datetime import datetime
+from typing import Optional
 
 
 def format_byte(size: float, dot=2):
@@ -146,7 +147,7 @@ def replace_date_time(text: str, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
 _BYTE_UNIT = ["B", "KB", "MB", "GB", "TB"]
 
 
-def get_byte_from_str(byte_str: str) -> int:
+def get_byte_from_str(byte_str: str) -> Optional[int]:
     """Get byte from str
 
     Parameters
@@ -175,7 +176,7 @@ def get_byte_from_str(byte_str: str) -> int:
     return None
 
 
-def truncate_filename(path: str, limit: int = 255):
+def truncate_filename(path: str, limit: int = 255) -> str:
     """Truncate filename to the max len.
 
     Parameters

--- a/utils/format.py
+++ b/utils/format.py
@@ -1,8 +1,10 @@
 """util format"""
 
 import math
+import os
 import re
 from datetime import datetime
+import unicodedata
 
 
 def format_byte(size: float, dot=2):
@@ -172,3 +174,28 @@ def get_byte_from_str(byte_str: str) -> int:
         return int(search_res.group(1)) * unit
 
     return None
+
+
+def truncate_filename(path: str, limit: int = 255):
+    """Truncate filename to the max len.
+
+    Parameters
+    ----------
+    path: str
+        File name path
+
+    limit: int
+        limit file name len(utf-8 byte)
+
+    Returns
+    -------
+    str
+        if file name len more than limit then return truncate filename or return filename
+
+    """
+    p, f = os.path.split(os.path.normpath(path))
+    f, e = os.path.splitext(f)
+    f_max = limit - len(e.encode('utf-8'))
+    f = unicodedata.normalize('NFC', f)
+    f_trunc = f.encode()[:f_max].decode('utf-8', errors='ignore')
+    return os.path.join(p, f_trunc + e)

--- a/utils/format.py
+++ b/utils/format.py
@@ -3,8 +3,8 @@
 import math
 import os
 import re
-from datetime import datetime
 import unicodedata
+from datetime import datetime
 
 
 def format_byte(size: float, dot=2):
@@ -101,13 +101,12 @@ def get_date_time(text: str, fmt: str) -> SearchDateTimeResult:
         if search_res:
             time_str = search_res.group(0)
             res.value = datetime.strptime(
-                time_str.replace("/", "-").replace(".",
-                                                   "-").strip(), format_list[i]
+                time_str.replace("/", "-").replace(".", "-").strip(), format_list[i]
             ).strftime(fmt)
             if search_res.start() != 0:
-                res.left_str = search_text[0: search_res.start()]
+                res.left_str = search_text[0 : search_res.start()]
             if search_res.end() + 1 <= len(search_text):
-                res.right_str = search_text[search_res.end():]
+                res.right_str = search_text[search_res.end() :]
             res.match = True
             return res
 
@@ -195,7 +194,7 @@ def truncate_filename(path: str, limit: int = 255):
     """
     p, f = os.path.split(os.path.normpath(path))
     f, e = os.path.splitext(f)
-    f_max = limit - len(e.encode('utf-8'))
-    f = unicodedata.normalize('NFC', f)
-    f_trunc = f.encode()[:f_max].decode('utf-8', errors='ignore')
+    f_max = limit - len(e.encode("utf-8"))
+    f = unicodedata.normalize("NFC", f)
+    f_trunc = f.encode()[:f_max].decode("utf-8", errors="ignore")
     return os.path.join(p, f_trunc + e)

--- a/utils/meta_data.py
+++ b/utils/meta_data.py
@@ -72,7 +72,7 @@ class MetaData:
             "media_file_name": self.media_file_name,
             "media_duration": self.media_duration,
             # small
-            "id" : self.message_id,
+            "id": self.message_id,
             "caption": self.message_caption,
             "file_size": self.media_file_size,
             "file_name": self.media_file_name,

--- a/utils/meta_data.py
+++ b/utils/meta_data.py
@@ -71,6 +71,11 @@ class MetaData:
             "media_height": self.media_height,
             "media_file_name": self.media_file_name,
             "media_duration": self.media_duration,
+            # small
+            "id" : self.message_id,
+            "caption": self.message_caption,
+            "file_size": self.media_file_size,
+            "file_name": self.media_file_name,
         }
 
     def get_meta_data(self, meta_obj):
@@ -78,7 +83,7 @@ class MetaData:
         # message
         self.message_date = getattr(meta_obj, "date", None)
 
-        self.message_caption = getattr(meta_obj, "caption", None)
+        self.message_caption = getattr(meta_obj, "caption", None) or ""
         self.message_id = getattr(meta_obj, "id", None)
 
         for kind in self.AVAILABLE_MEDIA:
@@ -89,7 +94,7 @@ class MetaData:
         else:
             return
 
-        self.media_file_name = getattr(media_obj, "file_name", None)
+        self.media_file_name = getattr(media_obj, "file_name", None) or ""
         self.media_file_size = getattr(media_obj, "file_size", None)
         self.media_width = getattr(media_obj, "width", None)
         self.media_height = getattr(media_obj, "height", None)


### PR DESCRIPTION
## 新功能
* 添加了部分更加简洁的元数据名称，如`media_file_name` 可以替换 为`file_name`, 原有`media_file_name` 仍然可以使用，更多请查看 [如何使用过滤器](https://github.com/tangyoha/telegram_media_downloader/wiki/How-to-use-Filter)
* 添加了更加简洁的数据表达形式，如 file_size > 1 * 1024 * 1024 可以替换为 file_size > 1MB 更多请查看 [如何使用过滤器](https://github.com/tangyoha/telegram_media_downloader/wiki/How-to-use-Filter)
## fix
* 修复了表达式无法使用中文的问题
* 修复了配置无法使用中文问题
* 修复了配置中`file_name_prefix_split`配置`file_name`不为最后一个导致文件无法访问问题
* 修复字符串匹配失败问题，如 file_name == r'.\*test.\*'
* 修复名称过长导致保存失败问题

# feat
* Added some more concise metadata names, such as `media_file_name` can be replaced by `file_name`, the original `media_file_name` can still be used, for more information, please refer to [How to use filters](https://github.com/tangyoha/telegram_media_downloader/wiki/How-to-use-Filter)
* Added a more concise data expression form, such as file_size > 1 * 1024 * 1024 can be replaced by file_size > 1MB For more information, please see [How to use filters](https://github.com/tangyoha/telegram_media_downloader/wiki/How-to-use-Filter)
* 
## fix
* Fixed the problem that expressions cannot use Chinese
* Fixed the problem that the configuration cannot use Chinese
* Fixed `file_name_prefix_split` configuration `file_name` not being the last one in the configuration, causing the file to be inaccessible
*  Fix string matching failure problem, such as file_name == r'.\*test.\*'
*  Fix the problem that the name is too long and the save fails