### PR TITLE
master_v.2.1.6

### DIFF
--- a/.github/docker-publish.yml
+++ b/.github/docker-publish.yml
@@ -1,0 +1,30 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: tangyoha/telegram-media-downloader:${{ github.ref_name }}

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -1,0 +1,84 @@
+name: Create Release and Upload Assets
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install dependencies and build
+        run: |
+          npm ci
+          npm run build
+
+      # - name: Extract Release Note
+      #   id: release_note
+      #   run: |
+      #     RELEASE_NOTE=$(awk -v tag="${{ github.ref }}" '/^## /{ if (found) { exit } if ($2 == tag) { found=1; } } { if (found) { printf "%s\n", $0 } }' CHANGELOG.md)
+      #     echo "RELEASE_NOTE<<EOF" >> $GITHUB_ENV
+      #     echo "$RELEASE_NOTE" >> $GITHUB_ENV
+      #     echo "EOF" >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ env.RELEASE_NOTE }}
+          draft: false
+          prerelease: false
+
+      # source code
+      - name: Create source code archives
+        run: |
+          git archive --format=tar.gz -o source_code.tar.gz HEAD
+          git archive --format=zip -o source_code.zip HEAD
+
+      - name: Upload source code archives
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: source_code.tar.gz
+          asset_name: Source code.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload source code archives
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: source_code.zip
+          asset_name: Source code.zip
+          asset_content_type: application/zip
+
+      # docker
+      - name: Archive docker files
+        run: |
+          tar -cvzf app.tar.gz ./log docker-compose.yaml config.yaml data.yaml
+
+      - name: Upload assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: app.tar.gz
+          asset_name: app.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -14,8 +14,10 @@ jobs:
 
       - name: Get Release Date
         run: |
-          DATE=$(date +%Y-%m-%d)
-          echo "::set-env name=RELEASE_NAME::$DATE"
+          RELEASE_DATE=$(date +%Y-%m-%d)
+          echo "RELEASE_DATE<<EOF" >> $GITHUB_ENV
+          echo "$RELEASE_DATE" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - name: Generate changelog
         id: changelog
         run: |
@@ -36,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }},${{ env.RELEASE_NAME }}
+          release_name: ${{ github.ref }},${{ env.RELEASE_DATE }}
           body: |
             ## What's Changed
             ${{ env.LOG }}

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -3,7 +3,7 @@ name: Create Release and Upload Assets
 on:
   push:
     tags:
-      - 'v*'
+      - 'vv*'
 
 jobs:
   release:
@@ -47,7 +47,7 @@ jobs:
       # docker
       - name: Archive docker files
         run: |
-          tar -cvzf app.tar.gz log docker-compose.yaml config.yaml data.yaml
+          tar -cvzf app.tar.gz docker-compose.yaml config.yaml data.yaml
 
       - name: Upload assets
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -13,22 +13,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get Release Date
+        id: release_date
         run: |
           RELEASE_DATE=$(date +%Y-%m-%d)
-          echo "RELEASE_DATE<<EOF" >> $GITHUB_ENV
-          echo "$RELEASE_DATE" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          echo "RELEASE_DATE=$RELEASE_DATE" | tee -a $GITHUB_ENV
+          echo "::set-output name=release_date::$RELEASE_DATE"
+
       - name: Generate changelog
         id: changelog
         run: |
           LOG=$(git log $(git describe --tags $(git rev-list --tags --max-count=2 | tail -n 1))..HEAD --pretty=format:'* %s by @%an in %H')
-          git rev-list --tags --max-count=2 | tail -n 1
-          git describe --tags $(git rev-list --tags --max-count=2 | tail -n 1)
-          git log $(git describe --tags $(git rev-list --tags --max-count=2 | tail -n 1))..HEAD --pretty=format:'* %s by @%an in %H'
-          echo $LOG
-          echo "LOG<<EOF" >> $GITHUB_ENV
-          echo "$LOG" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          echo "::set-output name=changelog::$LOG"
 
       - name: Create Release
         id: create_release
@@ -37,10 +32,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }},${{ env.RELEASE_DATE }}
+          release_name: ${{ github.ref }},${{ steps.release_date.outputs.release_date }}
           body: |
             ## What's Changed
-            ${{ env.LOG }}
+            ${{ steps.changelog.outputs.changelog }}
 
           draft: false
           prerelease: false

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -3,7 +3,7 @@ name: Create Release and Upload Assets
 on:
   push:
     tags:
-      - 'vv*'
+      - 'v*'
 
 jobs:
   release:

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Get Release Date
         id: release_date
@@ -22,7 +24,9 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
-          LOG=$(git log $(git describe --tags $(git rev-list --tags --max-count=2 | tail -n 1))..HEAD --pretty=format:'* %s by @%an in %H')
+          PREVIOUS_TAG=$(git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1`)
+          CURRENT_TAG=${{ github.ref }}
+          LOG=$(git log --pretty=format:'* %s by @%an in %H' $PREVIOUS_TAG...$CURRENT_TAG)
           echo "::set-output name=changelog::$LOG"
 
       - name: Create Release

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -12,15 +12,15 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
+      # - name: Set up Node.js
+      #   uses: actions/setup-node@v2
+      #   with:
+      #     node-version: 14
 
-      - name: Install dependencies and build
-        run: |
-          npm ci
-          npm run build
+      # - name: Install dependencies and build
+      #   run: |
+      #     npm ci
+      #     npm run build
 
       # - name: Extract Release Note
       #   id: release_note

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -22,6 +22,10 @@ jobs:
         id: changelog
         run: |
           LOG=$(git log $(git describe --tags $(git rev-list --tags --max-count=2 | tail -n 1))..HEAD --pretty=format:'* %s by @%an in %H')
+          git rev-list --tags --max-count=2 | tail -n 1
+          git describe --tags $(git rev-list --tags --max-count=2 | tail -n 1)
+          git log $(git describe --tags $(git rev-list --tags --max-count=2 | tail -n 1))..HEAD --pretty=format:'* %s by @%an in %H'
+          echo $LOG
           echo "LOG<<EOF" >> $GITHUB_ENV
           echo "$LOG" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -12,23 +12,22 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      # - name: Set up Node.js
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: 14
+      - name: Get Release Date
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          echo "::set-env name=RELEASE_NAME::$DATE"
+      - name: Generate changelog
+        id: changelog
+        run: |
+          LOG=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:'* %s by @%an in %H')
+          echo "LOG<<EOF" >> $GITHUB_ENV
+          echo "$LOG" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
-      # - name: Install dependencies and build
-      #   run: |
-      #     npm ci
-      #     npm run build
-
-      # - name: Extract Release Note
-      #   id: release_note
-      #   run: |
-      #     RELEASE_NOTE=$(awk -v tag="${{ github.ref }}" '/^## /{ if (found) { exit } if ($2 == tag) { found=1; } } { if (found) { printf "%s\n", $0 } }' CHANGELOG.md)
-      #     echo "RELEASE_NOTE<<EOF" >> $GITHUB_ENV
-      #     echo "$RELEASE_NOTE" >> $GITHUB_ENV
-      #     echo "EOF" >> $GITHUB_ENV
+          CONTRIBUTORS=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:'%an' | sort -u | awk '{print "* @" $0}')
+          echo "CONTRIBUTORS<<EOF" >> $GITHUB_ENV
+          echo "$CONTRIBUTORS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Create Release
         id: create_release
@@ -37,41 +36,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: ${{ env.RELEASE_NOTE }}
+          release_name: ${{ github.ref }},${{ env.RELEASE_NAME }}
+          body: |
+            ## What's Changed
+            ${{ env.LOG }}
+
+            ## New Contributors
+            ${{ env.CONTRIBUTORS }}
           draft: false
           prerelease: false
-
-      # source code
-      - name: Create source code archives
-        run: |
-          git archive --format=tar.gz -o source_code.tar.gz HEAD
-          git archive --format=zip -o source_code.zip HEAD
-
-      - name: Upload source code archives
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: source_code.tar.gz
-          asset_name: Source code.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload source code archives
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: source_code.zip
-          asset_name: Source code.zip
-          asset_content_type: application/zip
 
       # docker
       - name: Archive docker files
         run: |
-          tar -cvzf app.tar.gz ./log docker-compose.yaml config.yaml data.yaml
+          tar -cvzf app.tar.gz log docker-compose.yaml config.yaml data.yaml
 
       - name: Upload assets
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -21,14 +21,9 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
-          LOG=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:'* %s by @%an in %H')
+          LOG=$(git log $(git describe --tags $(git rev-list --tags --max-count=2 | tail -n 1))..HEAD --pretty=format:'* %s by @%an in %H')
           echo "LOG<<EOF" >> $GITHUB_ENV
           echo "$LOG" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-          CONTRIBUTORS=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:'%an' | sort -u | awk '{print "* @" $0}')
-          echo "CONTRIBUTORS<<EOF" >> $GITHUB_ENV
-          echo "$CONTRIBUTORS" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create Release
@@ -43,8 +38,6 @@ jobs:
             ## What's Changed
             ${{ env.LOG }}
 
-            ## New Contributors
-            ${{ env.CONTRIBUTORS }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,4 +27,6 @@ jobs:
       with:
         context: .
         push: true
-        tags: tangyoha/telegram-media-downloader:${{ github.ref_name }}
+        tags: |
+          ${{ secrets.DOCKER_HUB_USERNAME }}/telegram_media_downloader:latest
+          ${{ secrets.DOCKER_HUB_USERNAME }}/telegram_media_downloader:${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ video/
 video_note/
 parser.out
 parsetab.py
+local_test/
+.vscode
+TODO.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:latest
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --trusted-host pypi.python.org -r requirements.txt
+
+
+CMD ["python", "media_downloader.py"]

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@
   <a href="https://t.me/TeegramMediaDownload">Telegram Community</a>
 </h3>
 
-### Overview
+## Overview
+> Support two default running
 
-Download all media files from a conversation or a channel that you are a part of from telegram.
-A meta of last read/downloaded message is stored in the config file so that in such a way it won't download the same media file again.
+* The robot is running, and the command `download` or `forward` is issued from the robot
 
+* Download as a one-time download tool
 ### UI
 
 ![web](./screenshot/web_ui.gif)
@@ -43,7 +44,7 @@ After running, open the browser to visit `localhost:5000`
 
 * [v2.2.0](https://github.com/tangyoha/telegram_media_downloader/issues/2)
 
-### Installation
+## Installation
 
 For *nix os distributions with `make` availability
 
@@ -59,6 +60,28 @@ For Windows which doesn't have `make` inbuilt
 git clone https://github.com/tangyoha/telegram_media_downloader.git
 cd telegram_media_downloader
 pip3 install -r requirements.txt
+```
+
+## Docker
+> For more detailed installation tutorial, please check the wiki
+
+Make sure you have **docker** and **docker-compose** installed
+```sh
+docker pull tangyoha/telegram_media_downloader:latest
+mkdir -p ~/app && cd ~/app
+wget https://github.com/tangyoha/telegram_media_downloader/blob/master/docker-compose.yaml
+docker-compose run --rm telegram_media_downloader
+# The first time you need to start the foreground
+# enter your phone number and code, then exit(ctrl + c)
+
+# After performing the above operations, all subsequent startups will start in the background
+docker-compose up -d
+
+# Upgrade
+docker pull tangyoha/telegram_media_downloader:latest
+cd ~/app
+docker-compose down
+docker-compose up -d
 ```
 
 ## Upgrade installation

--- a/README_CN.md
+++ b/README_CN.md
@@ -22,10 +22,13 @@
   <a href="https://t.me/TeegramMediaDownload">电报讨论群</a>
 </h3>
 
-### 概述
+## 概述
 
-从您所属的电报对话或频道下载所有媒体文件。
-最后读取/下载消息的元数据存储在配置文件中，这样它就不会再次下载相同的媒体文件。
+> 支持两种默认运行
+
+* 机器人运行，从机器人下发命令`下载`或者`转发`
+
+* 作为一个一次性的下载工具下载
 
 ### 界面
 
@@ -44,7 +47,7 @@
 
 * [v2.2.0](https://github.com/tangyoha/telegram_media_downloader/issues/2)
 
-### 安装
+## 安装
 
 对于具有 `make` 可用性的 *nix 操作系统发行版
 
@@ -60,6 +63,35 @@ make install
 git clone https://github.com/tangyoha/telegram_media_downloader.git
 cd telegram_media_downloader
 pip3 install -r requirements.txt
+```
+## Docker容器
+> 更详细安装教程请查看wiki
+
+确保安装了 **docker** 和 **docker-compose**
+```sh
+docker pull tangyoha/telegram_media_downloader:latest
+mkdir -p ~/app && cd ~/app
+# 下载config.yaml模板
+wget https://raw.githubusercontent.com/tangyoha/telegram_media_downloader/master/config.yaml -O config.yaml
+# 修改配置
+vi config.yaml
+# 下载docker-compose模板
+wget https://raw.githubusercontent.com/tangyoha/telegram_media_downloader/master/docker-compose.yaml -O docker-compose.yaml
+# 修改 docker-compose
+vi docker-compose.yaml
+
+docker-compose run --rm telegram_media_downloader
+# 第一次需要前台启动
+# 输入你的电话号码和密码，然后退出(ctrl + c)
+
+# 执行完以上操作后，后面的所有启动都在后台启动
+docker-compose up -d
+
+＃ 升级
+docker pull tangyoha/telegram_media_downloader:latest
+cd ~/app
+docker-compose down
+docker-compose up -d
 ```
 
 ## 升级安装

--- a/config.yaml
+++ b/config.yaml
@@ -21,4 +21,4 @@ media_types:
 - voice
 - video_note
 # in linux please use /
-save_path: E:\github\telegram_media_downloader
+# save_path: E:\github\telegram_media_downloader

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,13 +10,11 @@ services:
     volumes:
       # Here is what you need to edit
       # - "/root/downloads/:/app/downloads/"
+      
       # The following is what you don't need to edit
-      # enable config
-      # - "./config.yaml:/app/config.yaml"
-      # enable data
-      # - "./data.yaml:/app/data.yaml"
-      #  enable log
-      "./log/:/app/log/"
+      - "./config.yaml:/app/config.yaml"
+      - "./data.yaml:/app/data.yaml"
+      - "./log/:/app/log/"
       - "sessions:/app/sessions"
       - "temp:/app/temp"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     volumes:
       # Here is what you need to edit
       # - "/root/downloads/:/app/downloads/"
-      
+
       # The following is what you don't need to edit
       - "./config.yaml:/app/config.yaml"
       - "./data.yaml:/app/data.yaml"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,25 @@
+version: "3.9"
+
+services:
+  telegram_media_downloader:
+    image: tangyoha/telegram_media_downloader:latest
+    build: .
+    ports:
+      # Here is what you need to edit
+      - "5000:5000"
+    volumes:
+      # Here is what you need to edit
+      # - "/root/downloads/:/app/downloads/"
+      # The following is what you don't need to edit
+      # enable config
+      # - "./config.yaml:/app/config.yaml"
+      # enable data
+      # - "./data.yaml:/app/data.yaml"
+      #  enable log
+      "./log/:/app/log/"
+      - "sessions:/app/sessions"
+      - "temp:/app/temp"
+
+volumes:
+  sessions:
+  temp:

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -40,6 +40,13 @@ DATA_FILE_NAME = "data.yaml"
 APPLICATION_NAME = "media_downloader"
 app = Application(CONFIG_NAME, DATA_FILE_NAME, APPLICATION_NAME)
 
+logger.add(
+    os.path.join(app.log_file_path, "tdl.log"),
+    rotation="10 MB",
+    retention="10 days",
+    level="DEBUG",
+)
+
 queue: asyncio.Queue = asyncio.Queue()
 RETRY_TIME_OUT = 1
 

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -515,7 +515,12 @@ async def download_all_chat(client: pyrogram.Client):
     """Download All chat"""
     for key, value in app.chat_download_config.items():
         node = DownloadTaskNode(chat_id=key)
-        await download_task(client, value, node)
+        try:
+            await download_task(client, value, node)
+        except Exception as e:
+            logger.exception(f"{e}")
+        finally:
+            value.need_check = True
 
 
 async def run_until_all_task_finish():

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -554,6 +554,7 @@ def main():
         api_id=app.api_id,
         api_hash=app.api_hash,
         proxy=app.proxy,
+        workdir=app.session_file_path,
     )
     try:
         app.pre_run()

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -66,7 +66,7 @@ def _check_download_finish(media_size: int, download_path: str, ui_file_name: st
     if media_size == download_size:
         logger.success("Media downloaded - {}", ui_file_name)
     else:
-        logger.error("Media downloaded with wrong size - {}", ui_file_name)
+        logger.warning("Media downloaded with wrong size - {}", ui_file_name)
         os.remove(download_path)
         raise pyrogram.errors.exceptions.bad_request_400.BadRequest()
 

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 import os
-import re
+import shutil
 import threading
 import time
 from typing import List, Optional, Tuple, Union
@@ -12,11 +12,17 @@ from loguru import logger
 from pyrogram.types import Audio, Document, Photo, Video, VideoNote, Voice
 from rich.logging import RichHandler
 
-from module.app import Application, ChatDownloadConfig, DownloadStatus
-from module.bot import start_download_bot
-from module.pyrogram_extension import get_extension
+from module.app import Application, ChatDownloadConfig, DownloadStatus, DownloadTaskNode
+from module.bot import start_download_bot, stop_download_bot
+from module.pyrogram_extension import (
+    get_extension,
+    record_download_status,
+    report_bot_status,
+    set_max_concurrent_transmissions,
+    upload_telegram_chat,
+)
 from module.web import get_flask_app, update_download_status
-from utils.format import truncate_filename
+from utils.format import truncate_filename, validate_title
 from utils.log import LogFilter
 from utils.meta import print_meta
 from utils.meta_data import MetaData
@@ -35,7 +41,7 @@ APPLICATION_NAME = "media_downloader"
 app = Application(CONFIG_NAME, DATA_FILE_NAME, APPLICATION_NAME)
 
 queue: asyncio.Queue = asyncio.Queue()
-RETRY_TIME_OUT = 5
+RETRY_TIME_OUT = 1
 
 logging.getLogger("pyrogram.session.session").addFilter(LogFilter())
 logging.getLogger("pyrogram.client").addFilter(LogFilter())
@@ -62,7 +68,25 @@ def _check_download_finish(media_size: int, download_path: str, ui_file_name: st
     else:
         logger.error("Media downloaded with wrong size - {}", ui_file_name)
         os.remove(download_path)
-        raise TypeError("Media downloaded with wrong size")
+        raise pyrogram.errors.exceptions.bad_request_400.BadRequest()
+
+
+def _move_to_download_path(temp_download_path: str, download_path: str):
+    """Move file to download path
+
+    Parameters
+    ----------
+    temp_download_path: str
+        Temporary download path
+
+    download_path: str
+        Download path
+
+    """
+
+    directory, _ = os.path.split(download_path)
+    os.makedirs(directory, exist_ok=True)
+    shutil.move(temp_download_path, download_path)
 
 
 def _check_timeout(retry: int, _: int):
@@ -80,21 +104,6 @@ def _check_timeout(retry: int, _: int):
     if retry == 2:
         return True
     return False
-
-
-def _validate_title(title: str):
-    """Fix if title validation fails
-
-    Parameters
-    ----------
-    title: str
-        Chat title
-
-    """
-
-    r_str = r"[\//\:\*\?\"\<\>\|\n]"  # '/ \ : * ? " < > |'
-    new_title = re.sub(r_str, "_", title)
-    return new_title
 
 
 def _can_download(_type: str, file_formats: dict, file_format: Optional[str]) -> bool:
@@ -149,7 +158,7 @@ async def _get_media_meta(
     message: pyrogram.types.Message,
     media_obj: Union[Audio, Document, Photo, Video, VideoNote, Voice],
     _type: str,
-) -> Tuple[str, Optional[str]]:
+) -> Tuple[str, str, Optional[str]]:
     """Extract file name and file id from media object.
 
     Parameters
@@ -161,7 +170,7 @@ async def _get_media_meta(
 
     Returns
     -------
-    Tuple[str, Optional[str]]
+    Tuple[str, str, Optional[str]]
         file_name, file_format
     """
     if _type in ["audio", "document", "video"]:
@@ -171,9 +180,10 @@ async def _get_media_meta(
         file_format = None
 
     file_name = None
-    dirname = _validate_title(f"{chat_id}")
+    temp_file_name = None
+    dirname = validate_title(f"{chat_id}")
     if message.chat and message.chat.title:
-        dirname = _validate_title(f"{message.chat.title}")
+        dirname = validate_title(f"{message.chat.title}")
 
     if message.date:
         datetime_dir_name = message.date.strftime("%Y_%m")
@@ -184,16 +194,16 @@ async def _get_media_meta(
         # pylint: disable = C0209
         file_format = media_obj.mime_type.split("/")[-1]  # type: ignore
         file_save_path = app.get_file_save_path(_type, dirname, datetime_dir_name)
-
-        file_name = os.path.join(
-            file_save_path,
-            "{} - {}_{}.{}".format(
-                message.id,
-                _type,
-                media_obj.date.isoformat(),  # type: ignore
-                file_format,
-            ),
+        file_name = "{} - {}_{}.{}".format(
+            message.id,
+            _type,
+            media_obj.date.isoformat(),  # type: ignore
+            file_format,
         )
+
+        temp_file_name = os.path.join(app.temp_save_path, dirname, file_name)
+
+        file_name = os.path.join(file_save_path, file_name)
     else:
         file_name = getattr(media_obj, "file_name", None)
         caption = getattr(message, "caption", None)
@@ -209,7 +219,7 @@ async def _get_media_meta(
             file_name, file_name_suffix = os.path.splitext(file_name_without_suffix)
 
         if caption:
-            caption = _validate_title(caption)
+            caption = validate_title(caption)
             app.set_caption_name(chat_id, message.media_group_id, caption)
         else:
             caption = app.get_caption_name(chat_id, message.media_group_id)
@@ -222,12 +232,17 @@ async def _get_media_meta(
         )
 
         file_save_path = app.get_file_save_path(_type, dirname, datetime_dir_name)
+
+        temp_file_name = os.path.join(app.temp_save_path, dirname, gen_file_name)
+
         file_name = os.path.join(file_save_path, gen_file_name)
-        file_name = truncate_filename(file_name)
-    return file_name, file_format
+    return truncate_filename(file_name), truncate_filename(temp_file_name), file_format
 
 
 # pylint: disable = R0915,R0914
+
+
+@record_download_status
 async def download_media(
     client: pyrogram.client.Client,
     message: pyrogram.types.Message,
@@ -266,7 +281,9 @@ async def download_media(
     int
         Current message id.
     """
+
     # pylint: disable = R0912
+
     file_name: str = ""
     ui_file_name: str = ""
     task_start_time: float = time.time()
@@ -277,7 +294,7 @@ async def download_media(
             _media = getattr(message, _type, None)
             if _media is None:
                 continue
-            file_name, file_format = await _get_media_meta(
+            file_name, temp_file_name, file_format = await _get_media_meta(
                 chat_id, message, _media, _type
             )
             media_size = getattr(_media, "file_size", 0)
@@ -288,21 +305,17 @@ async def download_media(
 
             if _can_download(_type, file_formats, file_format):
                 if _is_exist(file_name):
-                    # TODO: check if the file download complete
-                    # file_size = os.path.getsize(file_name)
-                    # media_size = getattr(_media, 'file_size')
-                    # if media_size is not None and file_size != media_size:
 
-                    # FIXME: if exist and not empty file skip
-                    logger.info(
-                        "id={} {} already download,download skipped.\n",
-                        message.id,
-                        ui_file_name,
-                    )
-
-                    return DownloadStatus.SkipDownload
+                    file_size = os.path.getsize(file_name)
+                    if file_size or file_size == media_size:
+                        logger.info(
+                            "id={} {} already download,download skipped.\n",
+                            message.id,
+                            ui_file_name,
+                        )
+                        return DownloadStatus.SkipDownload, None
             else:
-                return DownloadStatus.SkipDownload
+                return DownloadStatus.SkipDownload, None
 
             break
     except Exception as e:
@@ -312,18 +325,20 @@ async def download_media(
             e,
             exc_info=True,
         )
-        return DownloadStatus.FailedDownload
+        return DownloadStatus.FailedDownload, None
     if _media is None:
-        return DownloadStatus.SkipDownload
+        return DownloadStatus.SkipDownload, None
+
+    message_id = message.id
 
     for retry in range(3):
         try:
-            download_path = await client.download_media(
+            temp_download_path = await client.download_media(
                 message,
-                file_name=file_name,
+                file_name=temp_file_name,
                 progress=lambda down_byte, total_byte: update_download_status(
                     chat_id,
-                    message.id,
+                    message_id,
                     down_byte,
                     total_byte,
                     ui_file_name,
@@ -331,16 +346,17 @@ async def download_media(
                 ),
             )
 
-            if download_path and isinstance(download_path, str):
+            if temp_download_path and isinstance(temp_download_path, str):
+                _move_to_download_path(temp_download_path, file_name)
                 # TODO: if not exist file size or media
-                _check_download_finish(media_size, download_path, ui_file_name)
-                await app.upload_file(file_name)
-                return DownloadStatus.SuccessDownload
+                _check_download_finish(media_size, file_name, ui_file_name)
+                return DownloadStatus.SuccessDownload, file_name
         except pyrogram.errors.exceptions.bad_request_400.BadRequest:
             logger.warning(
                 "Message[{}]: file reference expired, refetching...",
                 message.id,
             )
+            await asyncio.sleep(RETRY_TIME_OUT)
             message = await client.get_messages(  # type: ignore
                 chat_id=message.chat.id,  # type: ignore
                 message_ids=message.id,
@@ -377,7 +393,7 @@ async def download_media(
             )
             break
 
-    return DownloadStatus.FailedDownload
+    return DownloadStatus.FailedDownload, None
 
 
 def _load_config():
@@ -400,36 +416,59 @@ def _check_config() -> bool:
 async def worker(client: pyrogram.client.Client):
     """Work for download task"""
     while app.is_running:
-        item = await queue.get()
-        message = item[0]
-        chat_id = item[1]
-        bot: pyrogram.Client = item[2]
-        from_user_id = item[3]
-        download_status = await download_media(
-            client, message, app.media_types, app.file_formats, chat_id
-        )
-        if not bot:
-            app.set_download_id(chat_id, message.id, download_status)
-        else:
-            await bot.send_message(
-                from_user_id,
-                f"from `{message.chat.title if message.chat else chat_id}`\n"
-                f"* message id : `{message.id}`\n"
-                f"* status: **{download_status.name}**",
+        try:
+            item = await queue.get()
+            message = item[0]
+            bot: pyrogram.Client = item[1]
+            node: DownloadTaskNode = item[2]
+            download_status, file_name = await download_media(
+                client, message, app.media_types, app.file_formats, node.chat_id
             )
+
+            if not bot:
+                app.set_download_id(node.chat_id, message.id, download_status)
+            elif node.reply_message_id:
+                await report_bot_status(bot, node, message, download_status)
+
+            # upload telegram
+            if node.upload_telegram_chat_id:
+                if download_status is DownloadStatus.SuccessDownload:
+                    await upload_telegram_chat(
+                        client, node.upload_telegram_chat_id, message, file_name
+                    )
+                    if app.after_upload_telegram_delete:
+                        os.remove(file_name)
+
+                # forward text
+                if (
+                    download_status is DownloadStatus.SkipDownload
+                    and message.text
+                    and bot
+                ):
+                    await upload_telegram_chat(
+                        client, node.upload_telegram_chat_id, message, file_name
+                    )
+
+            # rclone upload
+            if (
+                not node.upload_telegram_chat_id
+                and download_status is DownloadStatus.SuccessDownload
+            ):
+                await app.upload_file(file_name)
+        except Exception as e:
+            logger.exception(f"{e}")
 
 
 async def download_task(
     client: pyrogram.Client,
-    chat_id: Union[int, str],
     chat_download_config: ChatDownloadConfig,
+    node: DownloadTaskNode,
     limit: int = 0,
     bot: pyrogram.Client = None,
-    from_user_id: Union[int, str] = None,
 ):
     """Download all task"""
     messages_iter = client.get_chat_history(
-        chat_id,
+        node.chat_id,
         limit=limit,
         offset_id=chat_download_config.last_read_message_id,
         reverse=True,
@@ -437,23 +476,29 @@ async def download_task(
     if chat_download_config.ids_to_retry:
         logger.info("Downloading files failed during last run...")
         skipped_messages: list = await client.get_messages(  # type: ignore
-            chat_id=chat_id, message_ids=chat_download_config.ids_to_retry
+            chat_id=node.chat_id, message_ids=chat_download_config.ids_to_retry
         )
 
         for message in skipped_messages:
-            await queue.put((message, chat_id, bot, from_user_id))
+            await queue.put((message, bot, node))
             chat_download_config.total_task += 1
 
     async for message in messages_iter:  # type: ignore
         meta_data = MetaData()
+
+        caption = message.caption
+        if caption:
+            caption = validate_title(caption)
+            app.set_caption_name(node.chat_id, message.media_group_id, caption)
+        else:
+            caption = app.get_caption_name(node.chat_id, message.media_group_id)
         meta_data.get_meta_data(message)
-        if not app.need_skip_message(chat_id, message.id, meta_data):
-            await queue.put((message, chat_id, bot, from_user_id))
+        meta_data.message_caption = caption
+
+        if not app.need_skip_message(chat_download_config, message.id, meta_data):
+            await queue.put((message, bot, node))
             chat_download_config.total_task += 1
         else:
-            chat_download_config.last_read_message_id = max(
-                chat_download_config.last_read_message_id, message.id
-            )
             chat_download_config.downloaded_ids.append(message.id)
 
     chat_download_config.need_check = True
@@ -462,7 +507,8 @@ async def download_task(
 async def download_all_chat(client: pyrogram.Client):
     """Download All chat"""
     for key, value in app.chat_download_config.items():
-        await download_task(client, key, value)
+        node = DownloadTaskNode(chat_id=key)
+        await download_task(client, value, node)
 
 
 async def run_until_all_task_finish():
@@ -503,20 +549,15 @@ def main():
             target=get_flask_app().run, daemon=True, args=(app.web_host, app.web_port)
         ).start()
 
-        if getattr(client, "max_concurrent_transmissions", None):
-            client.max_concurrent_transmissions = app.max_concurrent_transmissions
-            client.save_file_semaphore = asyncio.Semaphore(
-                client.max_concurrent_transmissions
-            )
-            client.get_file_semaphore = asyncio.Semaphore(
-                client.max_concurrent_transmissions
-            )
+        set_max_concurrent_transmissions(client, app.max_concurrent_transmissions)
 
         client.start()
         print("Successfully started (Press Ctrl+C to stop)")
 
         if app.bot_token:
-            start_download_bot(app, client, download_media, download_task)
+            app.loop.create_task(
+                start_download_bot(app, client, download_media, download_task)
+            )
 
         app.loop.create_task(download_all_chat(client))
         for _ in range(app.max_download_task):
@@ -537,6 +578,8 @@ def main():
         check_for_updates()
         logger.info("update config......")
         app.update_config()
+        if app.bot_token:
+            stop_download_bot()
         logger.success(
             "Updated last read message_id to config file,"
             "total download {}, total upload file {}",

--- a/module/app.py
+++ b/module/app.py
@@ -545,7 +545,7 @@ class Application:
         if self.config.get("last_read_message_id"):
             self.config.pop("last_read_message_id")
 
-        self.config["language"] = self.language.value
+        self.config["language"] = self.language.name
         # for it in self.downloaded_ids:
         #    self.already_download_ids_set.add(it)
 

--- a/module/app.py
+++ b/module/app.py
@@ -77,10 +77,12 @@ class DownloadTaskNode:
 
     def can_reply(self):
         """
-        Checks if the bot can reply to a message based on the time elapsed since the last reply.
+        Checks if the bot can reply to a message
+            based on the time elapsed since the last reply.
 
         Returns:
-            True if the time elapsed since the last reply is greater than 1 second, False otherwise.
+            True if the time elapsed since
+                the last reply is greater than 1 second, False otherwise.
         """
         cur_time = time.time()
         if cur_time - self.last_reply_time > 1.0:

--- a/module/app.py
+++ b/module/app.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import re
+import time
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import List, Optional, Union
@@ -31,6 +32,62 @@ class DownloadStatus(Enum):
     SkipDownload = 1
     SuccessDownload = 2
     FailedDownload = 3
+    Downloading = 4
+
+
+class DownloadTaskNode:
+    """Download task node"""
+
+    def __init__(
+        self,
+        chat_id: Union[int, str],
+        from_user_id: Union[int, str] = None,
+        reply_message_id: int = 0,
+        replay_message: str = None,
+        upload_telegram_chat_id: Union[int, str] = None,
+    ):
+        self.chat_id = chat_id
+        self.from_user_id = from_user_id
+        self.upload_telegram_chat_id = upload_telegram_chat_id
+        self.reply_message_id = reply_message_id
+        self.reply_message = replay_message
+        self.total_download_task = 0
+        self.failed_download_task = 0
+        self.success_download_task = 0
+        self.skip_download_task = 0
+        self.last_reply_time = time.time()
+
+    def stat(self, status: DownloadStatus):
+        """
+        Updates the download status of the task.
+
+        Args:
+            status (DownloadStatus): The status of the download task.
+
+        Returns:
+            None
+        """
+        self.total_download_task += 1
+        if status is DownloadStatus.SuccessDownload:
+            self.success_download_task += 1
+        elif status is DownloadStatus.SkipDownload:
+            self.skip_download_task += 1
+        else:
+            self.failed_download_task += 1
+
+    def can_reply(self):
+        """
+        Checks if the bot can reply to a message based on the time elapsed since the last reply.
+
+        Returns:
+            True if the time elapsed since the last reply is greater than 1 second, False otherwise.
+        """
+        cur_time = time.time()
+        if cur_time - self.last_reply_time > 1.0:
+            self.last_reply_time = cur_time
+            return True
+
+        return False
 
 
 class ChatDownloadConfig:
@@ -42,12 +99,13 @@ class ChatDownloadConfig:
         self.ids_to_retry_dict: dict = {}
 
         # need storage
-        self.download_filter: list = []
+        self.download_filter: str = None
         self.ids_to_retry: list = []
         self.last_read_message_id = 0
         self.total_task: int = 0
         self.finish_task: int = 0
         self.need_check: bool = False
+        self.upload_telegram_chat_id: Union[int, str] = None
 
 
 class Application:
@@ -86,6 +144,7 @@ class Application:
 
         self.disable_syslog: list = []
         self.save_path = os.path.abspath(".")
+        self.temp_save_path = os.path.join(os.path.abspath("."), "download")
         self.api_id: str = ""
         self.api_hash: str = ""
         self.bot_token: str = ""
@@ -108,6 +167,7 @@ class Application:
         self.web_port: int = 5000
         self.max_download_task: int = 5
         self.language = Language.EN
+        self.after_upload_telegram_delete: bool = True
 
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
@@ -208,6 +268,10 @@ class Application:
             elif language == "EN":
                 self.language = Language.EN
 
+        self.after_upload_telegram_delete = _config.get(
+            "after_upload_telegram_delete", self.after_upload_telegram_delete
+        )
+
         if _config.get("chat"):
             chat = _config["chat"]
             for item in chat:
@@ -219,6 +283,11 @@ class Application:
                     self.chat_download_config[
                         item["chat_id"]
                     ].download_filter = item.get("download_filter", "")
+                    self.chat_download_config[
+                        item["chat_id"]
+                    ].upload_telegram_chat_id = item.get(
+                        "upload_telegram_chat_id", None
+                    )
         elif _config.get("chat_id"):
             # Compatible with lower versions
             self._chat_id = _config["chat_id"]
@@ -288,15 +357,20 @@ class Application:
                 self.app_data.pop("ids_to_retry")
         else:
             if app_data.get("chat"):
-                chat = app_data["chat"]
-                for item in chat:
+                chats = app_data["chat"]
+                for chat in chats:
                     if (
-                        "chat_id" in item
-                        and item["chat_id"] in self.chat_download_config
+                        "chat_id" in chat
+                        and chat["chat_id"] in self.chat_download_config
                     ):
-                        self.chat_download_config[
-                            item["chat_id"]
-                        ].ids_to_retry = item.get("ids_to_retry", [])
+                        chat_id = chat["chat_id"]
+                        self.chat_download_config[chat_id].ids_to_retry = chat.get(
+                            "ids_to_retry", []
+                        )
+                        for it in self.chat_download_config[chat_id].ids_to_retry:
+                            self.chat_download_config[chat_id].ids_to_retry_dict[
+                                it
+                            ] = True
         return True
 
     async def upload_file(self, local_file_path: str):
@@ -392,7 +466,7 @@ class Application:
         return res
 
     def need_skip_message(
-        self, chat_id: Union[int, str], message_id: int, meta_data: MetaData
+        self, download_config: ChatDownloadConfig, message_id: int, meta_data: MetaData
     ) -> bool:
         """if need skip download message.
 
@@ -411,10 +485,6 @@ class Application:
         -------
         bool
         """
-        if chat_id not in self.chat_download_config:
-            return False
-
-        download_config = self.chat_download_config[chat_id]
         if message_id in download_config.ids_to_retry_dict:
             return True
 
@@ -433,7 +503,8 @@ class Application:
         immediate: bool
             If update config immediate,default True
         """
-        if not self.app_data.get("chat"):
+        # TODO: fix this not exist chat
+        if not self.app_data.get("chat") and self.config.get("chat"):
             self.app_data["chat"] = [
                 {"chat_id": i} for i in range(0, len(self.config["chat"]))
             ]

--- a/module/app.py
+++ b/module/app.py
@@ -145,8 +145,8 @@ class Application:
         self.chat_download_config: dict = {}
 
         self.disable_syslog: list = []
-        self.save_path = os.path.abspath(".")
-        self.temp_save_path = os.path.join(os.path.abspath("."), "download")
+        self.save_path = os.path.join(os.path.abspath("."), "downloads")
+        self.temp_save_path = os.path.join(os.path.abspath("."), "temp")
         self.api_id: str = ""
         self.api_hash: str = ""
         self.bot_token: str = ""
@@ -161,6 +161,7 @@ class Application:
         self.file_name_prefix: List[str] = ["message_id", "file_name"]
         self.file_name_prefix_split: str = " - "
         self.log_file_path = os.path.join(os.path.abspath("."), "log")
+        self.session_file_path = os.path.join(os.path.abspath("."), "sessions")
         self.cloud_drive_config = CloudDriveConfig()
         self.hide_file_name = False
         self.caption_name_dict: dict = {}
@@ -569,14 +570,15 @@ class Application:
                 self.config = config
                 self.assign_config(self.config)
 
-        with open(
-            os.path.join(os.path.abspath("."), self.app_data_file),
-            encoding="utf-8",
-        ) as f:
-            app_data = _yaml.load(f.read())
-            if app_data:
-                self.app_data = app_data
-                self.assign_app_data(self.app_data)
+        if os.path.exists(os.path.join(os.path.abspath("."), self.app_data_file)):
+            with open(
+                os.path.join(os.path.abspath("."), self.app_data_file),
+                encoding="utf-8",
+            ) as f:
+                app_data = _yaml.load(f.read())
+                if app_data:
+                    self.app_data = app_data
+                    self.assign_app_data(self.app_data)
 
     def pre_run(self):
         """before run application do"""

--- a/module/app.py
+++ b/module/app.py
@@ -545,6 +545,7 @@ class Application:
         if self.config.get("last_read_message_id"):
             self.config.pop("last_read_message_id")
 
+        self.config["language"] = self.language.value
         # for it in self.downloaded_ids:
         #    self.already_download_ids_set.add(it)
 

--- a/module/bot.py
+++ b/module/bot.py
@@ -1,12 +1,27 @@
 """Bot for media downloader"""
 
-from typing import Callable
+import os
+from typing import Callable, List
 
 import pyrogram
+from pyrogram import types
 from pyrogram.handlers import MessageHandler
+from ruamel import yaml
 
-from module.app import Application, ChatDownloadConfig, Language
-from utils.format import extract_info_from_link
+from module.app import (
+    Application,
+    ChatDownloadConfig,
+    DownloadStatus,
+    DownloadTaskNode,
+    Language,
+)
+from module.filter import Filter
+from module.pyrogram_extension import report_bot_status
+from utils.format import extract_info_from_link, replace_date_time, validate_title
+from utils.meta_data import MetaData
+
+# from pyrogram.types import (ReplyKeyboardMarkup, InlineKeyboardMarkup,
+#                             InlineKeyboardButton)
 
 
 class DownloadBot:
@@ -18,8 +33,43 @@ class DownloadBot:
         self.download_task: Callable = None
         self.download_chat_task: Callable = None
         self.app = None
+        self.listen_forward_chat: dict = {}
+        self.config: dict = {}
+        self._yaml = yaml.YAML()
+        self.config_path = os.path.join(os.path.abspath("."), "bot.yaml")
+        self.download_command: dict = {}
+        self.filter = Filter()
 
-    def start(
+        meta = MetaData("2022/03/08 10:00:00", 0, "", 0, 0, 0, "", 0)
+        self.filter.set_meta_data(meta)
+
+        self.download_filter: List[str] = []
+
+    def assign_config(self, _config: dict):
+        """assign config from str.
+
+        Parameters
+        ----------
+        _config: dict
+            application config dict
+
+        Returns
+        -------
+        bool
+        """
+
+        self.download_filter = _config.get("download_filter", self.download_filter)
+
+        return True
+
+    def update_config(self):
+        """Update config from str."""
+        self.config["download_filter"] = self.download_filter
+
+        with open("d", "w", encoding="utf-8") as yaml_file:
+            self._yaml.dump(self.config, yaml_file)
+
+    async def start(
         self,
         app: Application,
         client: pyrogram.Client,
@@ -35,70 +85,257 @@ class DownloadBot:
             proxy=app.proxy,
         )
 
-        self.bot.add_handler(MessageHandler(download_from_bot))
+        # 命令列表
+        if app.language == Language.CN:
+            commands = [
+                types.BotCommand("help", "帮助"),
+                types.BotCommand("download", "下载视频，使用方法直接输入/download查看"),
+                types.BotCommand("forward", "转发视频，使用方法直接输入/forward查看"),
+                types.BotCommand("listen_forward", "监控转发，使用方法直接输入/listen_forward查看"),
+                types.BotCommand("add_filter", "添加下载过滤器"),
+                types.BotCommand("set_language", "设置语言"),
+            ]
+        else:
+            commands = [
+                types.BotCommand("help", "Help"),
+                types.BotCommand(
+                    "download",
+                    "To download the video, use the method to directly enter /download to view",
+                ),
+                types.BotCommand(
+                    "forward",
+                    "Forward video, use the method to directly enter /forward to view",
+                ),
+                types.BotCommand(
+                    "listen_forward",
+                    "Listen forward, use the method to directly enter /listen_forward to view",
+                ),
+                types.BotCommand(
+                    "add_filter",
+                    "Add download filter, use the method to directly enter /add_filter to view",
+                ),
+                types.BotCommand("set_language", "Set language"),
+            ]
 
+        self.bot.add_handler(
+            MessageHandler(
+                download_from_bot, filters=pyrogram.filters.command(["download"])
+            )
+        )
+        self.bot.add_handler(
+            MessageHandler(
+                forward_messages, filters=pyrogram.filters.command(["forward"])
+            )
+        )
+        self.bot.add_handler(
+            MessageHandler(download_forward_media, filters=pyrogram.filters.media)
+        )
+        self.bot.add_handler(
+            MessageHandler(
+                download_from_link, filters=pyrogram.filters.regex(r"^https://t.me.*")
+            )
+        )
+        self.bot.add_handler(
+            MessageHandler(
+                set_listen_forward_msg,
+                filters=pyrogram.filters.command(["listen_forward"]),
+            )
+        )
+        self.bot.add_handler(
+            MessageHandler(help_command, filters=pyrogram.filters.command(["help"]))
+        )
+        self.bot.add_handler(
+            MessageHandler(
+                set_language, filters=pyrogram.filters.command(["set_language"])
+            )
+        )
+        self.bot.add_handler(
+            MessageHandler(add_filter, filters=pyrogram.filters.command(["add_filter"]))
+        )
         self.client = client
+
+        self.client.add_handler(MessageHandler(listen_forward_msg))
 
         self.download_task = download_task
         self.download_chat_task = download_chat_task
 
         self.app = app
 
-        self.bot.start()
+        # load config
+        if os.path.exists(self.config_path):
+            with open(self.config_path, encoding="utf-8") as f:
+                config = self._yaml.load(f.read())
+                if config:
+                    self.config = config
+                    self.assign_config(self.config)
+
+        await self.bot.start()
+
+        # 添加命令列表
+        await self.bot.set_bot_commands(commands)
+        # TODO: add admin
+        # self.bot.set_my_commands(commands, scope=types.BotCommandScopeChatAdministrators(self.app.))
 
 
 _bot = DownloadBot()
 
 
-def start_download_bot(
+async def start_download_bot(
     app: Application,
     client: pyrogram.Client,
     download_task: Callable,
     download_chat_task: Callable,
 ):
     """Start download bot"""
-    _bot.start(app, client, download_task, download_chat_task)
+    await _bot.start(app, client, download_task, download_chat_task)
 
 
-# pylint: disable = R0912, R0915
-async def download_from_bot(client: pyrogram.Client, message: pyrogram.types.Message):
-    """Download from bot"""
+def stop_download_bot():
+    """Stop download bot"""
+    _bot.update_config()
+
+
+async def help_command(client: pyrogram.Client, message: pyrogram.types.Message):
+    """
+    Sends a message with the available commands and their usage.
+
+    Parameters:
+        client (pyrogram.Client): The client instance.
+        message (pyrogram.types.Message): The message object.
+
+    Returns:
+        None
+    """
+
     if _bot.app.language is Language.CN:
         msg = (
-            "参数错误，请按照参考格式输入:\n\n"
-            "1.下载普通群组所有消息\n"
-            "<i>/download https://t.me/fkdhlg</i>\n\n"
-            "私密群组(频道) 链接为随便复制一条群组消息链接\n\n"
-            "2.下载从第0条消息开始的所有消息\n"
-            "<i>/download https://t.me/12000000</i>\n\n"
-            "3.下载从第2条消息开始,100结束\n"
-            "<i>/download https://t.me/12000000 2</i>\n\n"
-            "4.下载从第2条消息开始,100结束\n"
-            "<i>/download https://t.me/12000000 2 100</i>\n\n"
-            "5. 直接下载，直接转发消息给你的机器人\n\n"
-            "6. 直接下载单条消息\n"
-            "<i>https://t.me/12000000/1</i>\n\n"
+            "**注意**：1表示整个聊天的开始，0表示整个聊天的结束，`[` `]` 表示可选项，非必填\n"
+            "可用命令:\n"
+            "/help - 显示可用命令\n"
+            # "/add_filter - 添加下载的过滤器\n"
+            "/download - 下载消息\n"
+            "/forward - 转发消息\n"
+            "/listen_forward - 监听转发消息\n"
+            "/set_language - 设置语言\n"
         )
     else:
         msg = (
-            "parameter error, please enter according to the reference format:\n\n"
-            "1. Download all messages of ordinary groups\n"
-            "<i>/download https://t.me/fkdhlg</i>\n\n"
-            "The private group (channel) link is just copy a group message link\n\n"
-            "2. Download all messages starting from message 0\n"
-            "<i>/download https://t.me/12000000</i>\n\n"
-            "3. The download starts from the 2nd message and ends at 100\n"
-            "<i>/download https://t.me/12000000 2</i>\n\n"
-            "4. The download starts from the 2nd message and ends at 100\n"
-            "<i>/download https://t.me/12000000 2 100</i>\n\n"
-            "5. Direct download, direct message to your robot\n\n"
-            "6. Directly download a single message\n"
-            "<i>https://t.me/12000000/1</i>\n\n"
+            "Note: 1 means the start of the entire chat, 0 means the end of the entire chat, `[` `]` means optional, not required\n"
+            "Available commands:\n"
+            "/help - Show available commands\n"
+            # "/add_filter - Add download filter\n"
+            "/download - Download messages\n"
+            "/forward - Forward messages\n"
+            "/listen_forward - Listen for forwarded messages\n"
+            "/set_language - Set language\n"
         )
+
+    await client.send_message(message.chat.id, msg)
+
+
+async def set_language(client: pyrogram.Client, message: pyrogram.types.Message):
+    """
+    Set the language of the bot.
+
+    Parameters:
+        client (pyrogram.Client): The pyrogram client.
+        message (pyrogram.types.Message): The message containing the command.
+
+    Returns:
+        None
+    """
+
+    if len(message.text.split()) != 2:
+        if _bot.app.language is Language.CN:
+            await client.send_message(
+                message.from_user.id, "无效的命令格式。请使用 /set_language cn/en"
+            )
+        else:
+            await client.send_message(
+                message.from_user.id,
+                "Invalid command format. Please use /set_language cn/en",
+            )
+        return
+
+    language = message.text.split()[1]
+
+    if language.lower() == "cn":
+        _bot.app.language = Language.CN
+        await client.send_message(message.from_user.id, "语言设置为中文")
+    elif language.lower() == "en":
+        _bot.app.language = Language.EN
+        await client.send_message(message.from_user.id, "Language set to English")
+    else:
+        if _bot.app.language is Language.CN:
+            await client.send_message(message.from_user.id, "无效的语言选项。请使用 cn/en")
+        else:
+            await client.send_message(
+                message.from_user.id, "Invalid language option. Please use cn/en"
+            )
+
+
+async def add_filter(client: pyrogram.Client, message: pyrogram.types.Message):
+    """
+    Set the download filter of the bot.
+
+    Parameters:
+        client (pyrogram.Client): The pyrogram client.
+        message (pyrogram.types.Message): The message containing the command.
+
+    Returns:
+        None
+    """
+
+    args = message.text.split(maxsplit=1)
+    if len(args) != 2:
+        if _bot.app.language is Language.CN:
+            await client.send_message(
+                message.from_user.id, "无效的命令格式。请使用 /add_filter 你的过滤规则"
+            )
+        else:
+            await client.send_message(
+                message.from_user.id,
+                "Invalid command format. Please use /add_filter your filter",
+            )
+        return
+
+    filter_str = replace_date_time(args[1])
+    res, err = _bot.filter.check_filter(filter_str)
+    if res:
+        _bot.app.down = args[1]
+        await client.send_message(
+            message.from_user.id, f"Add download filter : {args[1]}"
+        )
+    else:
+        if _bot.app.language is Language.CN:
+            await client.send_message(message.from_user.id, f"{err}\n检验错误,请重新添加!")
+        else:
+            await client.send_message(message.from_user.id, f"{err}\nPlease try again!")
+    return
+
+
+async def download_forward_media(
+    client: pyrogram.Client, message: pyrogram.types.Message
+):
+    """
+    Downloads the media from a forwarded message.
+
+    Parameters:
+        client (pyrogram.Client): The client instance.
+        message (pyrogram.types.Message): The message object.
+
+    Returns:
+        None
+    """
+
+    if _bot.app.language is Language.CN:
+        msg = "1. 直接下载，直接转发消息给你的机器人\n\n"
+    else:
+        msg = "1. Direct download, directly forward the message to your robot\n\n"
 
     if message.media:
         if getattr(message, message.media.value):
-            download_status = await _bot.download_task(
+            download_status, _ = await _bot.download_task(
                 client,
                 message,
                 _bot.app.media_types,
@@ -115,102 +352,454 @@ async def download_from_bot(client: pyrogram.Client, message: pyrogram.types.Mes
 
             return
 
-    if not message.text:
-        await client.send_message(
-            message.from_user.id, msg, parse_mode=pyrogram.enums.ParseMode.HTML
-        )
+    await client.send_message(
+        message.from_user.id, msg, parse_mode=pyrogram.enums.ParseMode.HTML
+    )
+
+
+async def download_from_link(client: pyrogram.Client, message: pyrogram.types.Message):
+    """
+    Downloads a single message from a Telegram link.
+
+    Parameters:
+        client (pyrogram.Client): The pyrogram client.
+        message (pyrogram.types.Message): The message containing the Telegram link.
+
+    Returns:
+        None
+    """
+
+    if not message.text or not message.text.startswith("https://t.me"):
         return
+    if _bot.app.language is Language.CN:
+        msg = "1. 直接下载单条消息\n" "<i>https://t.me/12000000/1</i>\n\n"
+    else:
+        msg = (
+            "1. Directly download a single message\n"
+            "<i>https://t.me/12000000/1</i>\n\n"
+        )
 
     text = message.text.split()
+    if len(text) != 1:
+        await client.send_message(
+            message.from_user.id, msg, parse_mode=pyrogram.enums.ParseMode.HTML
+        )
 
-    if len(text) == 1:
-        chat_id, message_id = extract_info_from_link(text[0])
-        entity = None
+    chat_id, message_id = extract_info_from_link(text[0])
+
+    entity = None
+    if chat_id:
+        entity = await _bot.client.get_chat(chat_id)
+    if entity:
+        chat_title = entity.title
+        reply_message = f"from {chat_title} "
+        chat_download_config = ChatDownloadConfig()
+        if message_id:
+            # download signal message
+            limit = 1
+            chat_download_config.last_read_message_id = message_id
+            reply_message += f"download message id = {message_id} !\n......"
+            last_reply_message = await client.send_message(
+                message.from_user.id, reply_message
+            )
+            node = DownloadTaskNode(
+                chat_id=entity.id,
+                from_user_id=message.from_user.id,
+                reply_message_id=last_reply_message.id,
+                replay_message=reply_message,
+            )
+
+            await _bot.download_chat_task(
+                _bot.client,
+                chat_download_config,
+                node,
+                limit,
+                _bot.bot,
+            )
+            await client.edit_message_text(
+                message.from_user.id,
+                last_reply_message.id,
+                f"{node.reply_message}\ntotal task is {chat_download_config.total_task}",
+            )
+            return
+
+    await client.send_message(
+        message.from_user.id, msg, parse_mode=pyrogram.enums.ParseMode.HTML
+    )
+
+
+# pylint: disable = R0912, R0915
+
+
+async def download_from_bot(client: pyrogram.Client, message: pyrogram.types.Message):
+    """Download from bot"""
+    if _bot.app.language is Language.CN:
+        msg = (
+            "参数错误，请按照参考格式输入:\n\n"
+            "1.下载普通群组所有消息\n"
+            "<i>/download https://t.me/fkdhlg 1 0</i>\n\n"
+            "私密群组(频道) 链接为随便复制一条群组消息链接\n\n"
+            "2.下载从第N条消息开始的到第M条信息结束，M为0的时候表示到最后一条信息,过滤器为可选\n"
+            "<i>/download https://t.me/12000000 N M [过滤器]</i>\n\n"
+        )
+    else:
+        msg = (
+            "Parameter error, please enter according to the reference format:\n\n"
+            "1. Download all messages of common group\n"
+            "<i>/download https://t.me/fkdhlg 1 0</i>\n\n"
+            "The private group (channel) link is a random group message link\n\n"
+            "2. The download starts from the N message to the end of the M message. "
+            "When M is 0, it means the last message. The filter is optional\n"
+            "<i>/download https://t.me/12000000 N M [filter]</i>\n\n"
+        )
+
+    args = message.text.split(maxsplit=4)
+    if not message.text or len(args) < 4:
+        await client.send_message(
+            message.from_user.id, msg, parse_mode=pyrogram.enums.ParseMode.HTML
+        )
+        return
+
+    url = args[1]
+    offset_id = int(args[2])
+
+    limit = int(args[3])
+    if limit:
+        if limit < offset_id:
+            raise ValueError("M > N")
+
+        limit = limit - offset_id + 1
+
+    download_filter = args[4] if len(args) > 4 else None
+
+    if download_filter:
+        download_filter = replace_date_time(download_filter)
+        res, err = _bot.filter.check_filter(download_filter)
+        if not res:
+            await client.send_message(
+                message.from_user.id, err, reply_to_message_id=message.id
+            )
+    try:
+        chat_id, _ = extract_info_from_link(url)
         if chat_id:
             entity = await _bot.client.get_chat(chat_id)
-
         if entity:
             chat_title = entity.title
-
             reply_message = f"from {chat_title} "
-
             chat_download_config = ChatDownloadConfig()
-
-            if message_id:
-                # download signal message
-                limit = 1
-                chat_download_config.last_read_message_id = message_id
-                reply_message += f"download message id = {message_id} !"
-
-                await client.send_message(message.from_user.id, reply_message)
-                await _bot.download_chat_task(
-                    _bot.client,
-                    entity.id,
-                    chat_download_config,
-                    limit,
-                    _bot.bot,
-                    message.from_user.id,
-                )
-                return
-
-        await client.send_message(
-            message.from_user.id, msg, parse_mode=pyrogram.enums.ParseMode.HTML
-        )
+            chat_download_config.last_read_message_id = offset_id
+            chat_download_config.download_filter = download_filter
+            reply_message += f"download message id = {offset_id} limit = {limit} !"
+            last_reply_message = await client.send_message(
+                message.from_user.id, reply_message, reply_to_message_id=message.id
+            )
+            node = DownloadTaskNode(
+                chat_id=entity.id,
+                from_user_id=message.from_user.id,
+                reply_message_id=last_reply_message.id,
+                replay_message=reply_message,
+            )
+            await _bot.download_chat_task(
+                _bot.client,
+                chat_download_config,
+                node,
+                limit,
+                _bot.bot,
+            )
+    except Exception as e:
+        if _bot.app.language is Language.CN:
+            await client.send_message(
+                message.from_user.id,
+                "chat输入错误，请输入频道或群组的链接\n\n" f"错误类型：{e.__class__}" f"异常消息：{e}",
+            )
+        else:
+            await client.send_message(
+                message.from_user.id,
+                "chat input error, please enter the channel or group link\n\n"
+                f"Error type: {e.__class__}"
+                f"Exception message: {e}",
+            )
         return
 
-    if len(text) >= 2:
-        url = text[1]
-        offset_id = 0
-        limit = 0
-        if len(text) >= 3:
-            offset_id = int(text[2])
-        if len(text) >= 4:
-            if int(text[3]) < offset_id:
-                raise ValueError("limit id > offset id")
-            limit = int(text[3]) - offset_id + 1
 
+async def forward_messages(client: pyrogram.Client, message: pyrogram.types.Message):
+    """
+    Forwards messages from one chat to another.
+
+    Parameters:
+        client (pyrogram.Client): The pyrogram client.
+        message (pyrogram.types.Message): The message containing the command.
+
+    Returns:
+        None
+    """
+
+    async def report_error(client: pyrogram.Client, message: pyrogram.types.Message):
+        """report erorr"""
+
+        if _bot.app.language is Language.CN:
+            await client.send_message(
+                message.from_user.id,
+                "无效的命令格式。请使用 /forward https://t.me/c/src_chat https://t.me/c/dst_chat 1 400 `[`过滤器`]`\n",
+            )
+        else:
+            await client.send_message(
+                message.from_user.id,
+                "Invalid command format. Please use /forward https://t.me/c/src_chat https://t.me/c/dst_chat 1 400 `[`filter`]`",
+            )
+        return
+
+    args = message.text.split(maxsplit=5)
+    if len(args) < 5:
+        await report_error(client, message)
+        return
+
+    src_chat_link = args[1]
+    dst_chat_link = args[2]
+
+    try:
+        offset_id = int(args[3])
+        limit = int(args[4])
+    except Exception:
+        await report_error(client, message)
+        return
+
+    if limit:
+        if limit < offset_id:
+            raise ValueError("limit id > offset id")
+
+        limit = limit - offset_id + 1
+
+    download_filter = args[5] if len(args) > 5 else None
+
+    src_chat_id, _ = extract_info_from_link(src_chat_link)
+    dst_chat_id, _ = extract_info_from_link(dst_chat_link)
+
+    if not src_chat_id or not dst_chat_id:
+        if _bot.app.language is Language.CN:
+            await client.send_message(
+                message.from_user.id, "无效的聊天链接", reply_to_message_id=message.id
+            )
+        else:
+            await client.send_message(
+                message.from_user.id,
+                "Invalid chat link",
+                reply_to_message_id=message.id,
+            )
+        return
+
+    try:
+        src_chat = await _bot.client.get_chat(src_chat_id)
+        dst_chat = await _bot.client.get_chat(dst_chat_id)
+    except Exception:
+        if _bot.app.language is Language.CN:
+            await client.send_message(
+                message.from_user.id, "无效的聊天链接", reply_to_message_id=message.id
+            )
+        else:
+            await client.send_message(
+                message.from_user.id,
+                "Invalid chat link",
+                reply_to_message_id=message.id,
+            )
+        return
+
+    me = await client.get_me()
+    if dst_chat.id == me.id:
+        if _bot.app.language is Language.CN:
+            # TODO: when bot receive message judge if download
+            await client.send_message(
+                message.from_user.id,
+                "不能转发给该机器人，会导致无限循环",
+                reply_to_message_id=message.id,
+            )
+        else:
+            await client.send_message(
+                message.from_user.id,
+                "Can not forward to self",
+                reply_to_message_id=message.id,
+            )
+        return
+
+    if download_filter:
+        download_filter = replace_date_time(download_filter)
+        res, err = _bot.filter.check_filter(download_filter)
+        if not res:
+            await client.send_message(
+                message.from_user.id, err, reply_to_message_id=message.id
+            )
+
+    last_reply_message = await client.send_message(
+        message.from_user.id,
+        "Forwarding message, please wait...",
+        reply_to_message_id=message.id,
+    )
+
+    node = DownloadTaskNode(
+        chat_id=src_chat_id,
+        from_user_id=message.from_user.id,
+        upload_telegram_chat_id=dst_chat_id,
+        reply_message_id=last_reply_message.id,
+        replay_message=last_reply_message.text,
+    )
+
+    if not src_chat.has_protected_content:
+        last_read_message_id = offset_id
         try:
-            chat_id, message_id = extract_info_from_link(url)
+            async for item in _bot.client.get_chat_history(
+                src_chat.id,
+                limit=limit,
+                offset_id=offset_id,
+                reverse=True,
+            ):
+                # TODO if not exist filter forward 10 per
+                # await _bot.client.forward_messages(dst_chat_id, src_chat_id, list(range(i, i + 10)))
+                if download_filter:
+                    meta_data = MetaData()
+                    caption = item.caption
+                    if caption:
+                        caption = validate_title(caption)
+                        _bot.app.set_caption_name(
+                            src_chat_id, item.media_group_id, caption
+                        )
+                    else:
+                        caption = _bot.app.get_caption_name(
+                            src_chat_id, item.media_group_id
+                        )
 
-            if chat_id:
-                entity = await _bot.client.get_chat(chat_id)
+                    meta_data.get_meta_data(item)
+                    if not _bot.filter.exec(download_filter):
+                        continue
+                status = DownloadStatus.SuccessDownload
+                try:
+                    await _bot.client.forward_messages(
+                        dst_chat.id, src_chat.id, item.id
+                    )
+                except Exception:
+                    status = DownloadStatus.FailedDownload
 
-            if entity:
-                chat_title = entity.title
+                await report_bot_status(client, node, item, status)
+                last_read_message_id = item.id
 
-                reply_message = f"from {chat_title} "
-
-                chat_download_config = ChatDownloadConfig()
-
-                chat_download_config.last_read_message_id = offset_id
-                reply_message += f"download message id = {offset_id} limit = {limit} !"
-
-                await client.send_message(message.from_user.id, reply_message)
-
-                await _bot.download_chat_task(
-                    _bot.client,
-                    entity.id,
-                    chat_download_config,
-                    limit,
-                    _bot.bot,
-                    message.from_user.id,
-                )
         except Exception as e:
             if _bot.app.language is Language.CN:
-                await client.send_message(
+                await client.edit_message_text(
                     message.from_user.id,
-                    "chat输入错误，请输入频道或群组的链接\n\n" f"错误类型：{e.__class__}" f"异常消息：{e}",
+                    last_reply_message.id,
+                    f"转发消息 {last_read_message_id} - {offset_id + limit} 失败 : {e}",
                 )
             else:
-                await client.send_message(
+                await client.edit_message_text(
                     message.from_user.id,
-                    "chat input error, please enter the channel or group link\n\n"
-                    f"Error type: {e.__class__}"
-                    f"Exception message: {e}",
+                    last_reply_message.id,
+                    f"Error forwarding message {last_read_message_id} - {offset_id + limit} {e}",
                 )
-            return
+
     else:
-        await client.send_message(
-            message.from_user.id, msg, parse_mode=pyrogram.enums.ParseMode.HTML
+        chat_download_config = ChatDownloadConfig()
+        chat_download_config.last_read_message_id = offset_id
+        chat_download_config.download_filter = download_filter
+
+        await _bot.download_chat_task(
+            _bot.client,
+            chat_download_config,
+            node,
+            limit,
+            _bot.bot,
         )
+
+
+async def set_listen_forward_msg(
+    client: pyrogram.Client, message: pyrogram.types.Message
+):
+    """
+    Set the chat to listen for forwarded messages.
+
+    Args:
+        client (pyrogram.Client): The pyrogram client.
+        message (pyrogram.types.Message): The message sent by the user.
+
+    Returns:
+        None
+    """
+    args = message.text.split(maxsplit=3)
+
+    if len(args) < 3:
+        if _bot.app.language is Language.CN:
+            await client.send_message(
+                message.from_user.id,
+                "无效的命令格式。请使用 /listen_forward https://t.me/c/src_chat https://t.me/c/dst_chat [过滤器]",
+            )
+        else:
+            await client.send_message(
+                message.from_user.id,
+                "Invalid command format. Please use /listen_forward https://t.me/c/src_chat https://t.me/c/dst_chat [filter]\n",
+            )
         return
+
+    src_chat_link = args[1]
+    dst_chat_link = args[2]
+
+    src_chat_id, _ = extract_info_from_link(src_chat_link)
+    dst_chat_id, _ = extract_info_from_link(dst_chat_link)
+
+    try:
+        src_chat = await _bot.client.get_chat(src_chat_id)
+        dst_chat = await _bot.client.get_chat(dst_chat_id)
+    except Exception:
+        if _bot.app.language is Language.CN:
+            await client.send_message(
+                message.from_user.id, "无效的聊天链接", reply_to_message_id=message.id
+            )
+        else:
+            await client.send_message(
+                message.from_user.id,
+                "Invalid chat link",
+                reply_to_message_id=message.id,
+            )
+        return
+
+    _bot.listen_forward_chat[src_chat.id] = (
+        dst_chat.id,
+        replace_date_time(args[3]) if len(args) > 3 else None,
+    )
+
+
+async def listen_forward_msg(client: pyrogram.Client, message: pyrogram.types.Message):
+    """
+    Forwards messages from a chat to another chat if the message does not contain protected content.
+    If the message contains protected content, it will be downloaded and forwarded to the other chat.
+
+    Parameters:
+        client (pyrogram.Client): The pyrogram client.
+        message (pyrogram.types.Message): The message to be forwarded.
+    """
+
+    if message.chat and message.chat.id in _bot.listen_forward_chat:
+        chat_id, download_filter = _bot.listen_forward_chat[message.chat.id]
+
+        last_reply_message = await client.send_message(
+            message.from_user.id, "Forwarding message, please wait..."
+        )
+        if not message.chat.has_protected_content:
+            await _bot.client.forward_messages(
+                chat_id=chat_id, from_chat_id=message.chat.id, message_ids=message.id
+            )
+        else:
+            chat_download_config = ChatDownloadConfig()
+            chat_download_config.last_read_message_id = message.id
+            chat_download_config.download_filter = download_filter
+            node = DownloadTaskNode(
+                chat_id=message.chat.id,
+                from_user_id=message.from_user.id,
+                upload_telegram_chat_id=chat_id,
+                reply_message_id=last_reply_message.id,
+                replay_message=last_reply_message.text,
+            )
+            await _bot.download_chat_task(
+                _bot.client,
+                chat_download_config,
+                node,
+                1,
+                _bot.bot,
+            )

--- a/module/bot.py
+++ b/module/bot.py
@@ -84,6 +84,7 @@ class DownloadBot:
             api_hash=app.api_hash,
             api_id=app.api_id,
             bot_token=app.bot_token,
+            workdir=app.session_file_path,
             proxy=app.proxy,
         )
 

--- a/module/bot.py
+++ b/module/bot.py
@@ -23,6 +23,8 @@ from utils.meta_data import MetaData
 # from pyrogram.types import (ReplyKeyboardMarkup, InlineKeyboardMarkup,
 #                             InlineKeyboardButton)
 
+# pylint: disable = C0301, R0902
+
 
 class DownloadBot:
     """Download bot"""
@@ -220,7 +222,8 @@ async def help_command(client: pyrogram.Client, message: pyrogram.types.Message)
         )
     else:
         msg = (
-            "Note: 1 means the start of the entire chat, 0 means the end of the entire chat, `[` `]` means optional, not required\n"
+            "Note: 1 means the start of the entire chat, "
+            "0 means the end of the entire chat, `[` `]` means optional, not required\n"
             "Available commands:\n"
             "/help - Show available commands\n"
             # "/add_filter - Add download filter\n"
@@ -372,7 +375,7 @@ async def download_from_link(client: pyrogram.Client, message: pyrogram.types.Me
     if not message.text or not message.text.startswith("https://t.me"):
         return
     if _bot.app.language is Language.CN:
-        msg = "1. 直接下载单条消息\n" "<i>https://t.me/12000000/1</i>\n\n"
+        msg = "1. 直接下载单条消息\n<i>https://t.me/12000000/1</i>\n\n"
     else:
         msg = (
             "1. Directly download a single message\n"
@@ -419,7 +422,8 @@ async def download_from_link(client: pyrogram.Client, message: pyrogram.types.Me
             await client.edit_message_text(
                 message.from_user.id,
                 last_reply_message.id,
-                f"{node.reply_message}\ntotal task is {chat_download_config.total_task}",
+                f"{node.reply_message}\n"
+                f"total task is {chat_download_config.total_task}",
             )
             return
 
@@ -428,7 +432,7 @@ async def download_from_link(client: pyrogram.Client, message: pyrogram.types.Me
     )
 
 
-# pylint: disable = R0912, R0915
+# pylint: disable = R0912, R0915,R0914
 
 
 async def download_from_bot(client: pyrogram.Client, message: pyrogram.types.Message):
@@ -439,7 +443,8 @@ async def download_from_bot(client: pyrogram.Client, message: pyrogram.types.Mes
             "1.下载普通群组所有消息\n"
             "<i>/download https://t.me/fkdhlg 1 0</i>\n\n"
             "私密群组(频道) 链接为随便复制一条群组消息链接\n\n"
-            "2.下载从第N条消息开始的到第M条信息结束，M为0的时候表示到最后一条信息,过滤器为可选\n"
+            "2.下载从第N条消息开始的到第M条信息结束，"
+            "M为0的时候表示到最后一条信息,过滤器为可选\n"
             "<i>/download https://t.me/12000000 N M [过滤器]</i>\n\n"
         )
     else:
@@ -522,6 +527,7 @@ async def download_from_bot(client: pyrogram.Client, message: pyrogram.types.Mes
         return
 
 
+# pylint: disable = R0914
 async def forward_messages(client: pyrogram.Client, message: pyrogram.types.Message):
     """
     Forwards messages from one chat to another.
@@ -535,17 +541,21 @@ async def forward_messages(client: pyrogram.Client, message: pyrogram.types.Mess
     """
 
     async def report_error(client: pyrogram.Client, message: pyrogram.types.Message):
-        """report erorr"""
+        """Report error"""
 
         if _bot.app.language is Language.CN:
             await client.send_message(
                 message.from_user.id,
-                "无效的命令格式。请使用 /forward https://t.me/c/src_chat https://t.me/c/dst_chat 1 400 `[`过滤器`]`\n",
+                "无效的命令格式。请使用 "
+                "/forward https://t.me/c/src_chat https://t.me/c/dst_chat "
+                "1 400 `[`过滤器`]`\n",
             )
         else:
             await client.send_message(
                 message.from_user.id,
-                "Invalid command format. Please use /forward https://t.me/c/src_chat https://t.me/c/dst_chat 1 400 `[`filter`]`",
+                "Invalid command format. "
+                "Please use /forward https://t.me/c/src_chat https://t.me/c/dst_chat "
+                "1 400 `[`filter`]`",
             )
         return
 
@@ -728,12 +738,14 @@ async def set_listen_forward_msg(
         if _bot.app.language is Language.CN:
             await client.send_message(
                 message.from_user.id,
-                "无效的命令格式。请使用 /listen_forward https://t.me/c/src_chat https://t.me/c/dst_chat [过滤器]",
+                "无效的命令格式。请使用 /listen_forward "
+                "https://t.me/c/src_chat https://t.me/c/dst_chat [过滤器]",
             )
         else:
             await client.send_message(
                 message.from_user.id,
-                "Invalid command format. Please use /listen_forward https://t.me/c/src_chat https://t.me/c/dst_chat [filter]\n",
+                "Invalid command format. Please use /listen_forward "
+                "https://t.me/c/src_chat https://t.me/c/dst_chat [filter]\n",
             )
         return
 

--- a/module/bot.py
+++ b/module/bot.py
@@ -147,6 +147,9 @@ class DownloadBot:
             MessageHandler(help_command, filters=pyrogram.filters.command(["help"]))
         )
         self.bot.add_handler(
+            MessageHandler(help_command, filters=pyrogram.filters.command(["start"]))
+        )
+        self.bot.add_handler(
             MessageHandler(
                 set_language, filters=pyrogram.filters.command(["set_language"])
             )
@@ -211,7 +214,6 @@ async def help_command(client: pyrogram.Client, message: pyrogram.types.Message)
 
     if _bot.app.language is Language.CN:
         msg = (
-            "**注意**：1表示整个聊天的开始，0表示整个聊天的结束，`[` `]` 表示可选项，非必填\n"
             "可用命令:\n"
             "/help - 显示可用命令\n"
             # "/add_filter - 添加下载的过滤器\n"
@@ -219,11 +221,11 @@ async def help_command(client: pyrogram.Client, message: pyrogram.types.Message)
             "/forward - 转发消息\n"
             "/listen_forward - 监听转发消息\n"
             "/set_language - 设置语言\n"
+            "**注意**：1表示整个聊天的开始，"
+            "0表示整个聊天的结束\n`[` `]` 表示可选项，非必填\n"
         )
     else:
         msg = (
-            "Note: 1 means the start of the entire chat, "
-            "0 means the end of the entire chat, `[` `]` means optional, not required\n"
             "Available commands:\n"
             "/help - Show available commands\n"
             # "/add_filter - Add download filter\n"
@@ -231,6 +233,9 @@ async def help_command(client: pyrogram.Client, message: pyrogram.types.Message)
             "/forward - Forward messages\n"
             "/listen_forward - Listen for forwarded messages\n"
             "/set_language - Set language\n"
+            "Note: 1 means the start of the entire chat,"
+            "0 means the end of the entire chat\n"
+            "`[` `]` means optional, not required\n"
         )
 
     await client.send_message(message.chat.id, msg)

--- a/module/bot.py
+++ b/module/bot.py
@@ -471,9 +471,15 @@ async def download_from_bot(client: pyrogram.Client, message: pyrogram.types.Mes
         return
 
     url = args[1]
-    offset_id = int(args[2])
+    try:
+        offset_id = int(args[2])
+        limit = int(args[3])
+    except Exception:
+        await client.send_message(
+            message.from_user.id, msg, parse_mode=pyrogram.enums.ParseMode.HTML
+        )
+        return
 
-    limit = int(args[3])
     if limit:
         if limit < offset_id:
             raise ValueError("M > N")

--- a/module/filter.py
+++ b/module/filter.py
@@ -314,8 +314,8 @@ class BaseFilter:
     def p_error(self, p):
         if p:
             raise ValueError(f"Syntax error at '{p.value}'")
-        else:
-            raise ValueError("Syntax error at EOF")
+
+        raise ValueError("Syntax error at EOF")
 
     def check_type(self, p):
         """Check filter type if is right"""

--- a/module/filter.py
+++ b/module/filter.py
@@ -2,7 +2,7 @@
 
 import re
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 from ply import lex, yacc
 
@@ -360,7 +360,7 @@ class Filter:
             return False
         raise ValueError("meta data cannot be empty!")
 
-    def check_filter(self, filter_str: str) -> tuple[bool, Optional[str]]:
+    def check_filter(self, filter_str: str) -> Tuple[bool, Optional[str]]:
         """check filter str"""
         try:
             return not self.exec(filter_str) is None, None

--- a/module/filter.py
+++ b/module/filter.py
@@ -275,6 +275,10 @@ class BaseFilter:
         "expression : TIME"
         p[0] = p[1]
 
+    def p_expression_byte(self, p):
+        "expression : BYTE"
+        p[0] = p[1]
+
     def p_expression_name(self, p):
         "expression : NAME"
         try:

--- a/module/pyrogram_extension.py
+++ b/module/pyrogram_extension.py
@@ -1,10 +1,14 @@
 """Pyrogram ext"""
 
+import asyncio
 import struct
+from functools import wraps
 from io import BytesIO, StringIO
 from mimetypes import MimeTypes
-from typing import Optional
+from typing import List, Optional, Union
 
+import pyrogram
+from pyrogram.client import Cache
 from pyrogram.file_id import (
     FILE_REFERENCE_FLAG,
     PHOTO_TYPES,
@@ -15,8 +19,16 @@ from pyrogram.file_id import (
 )
 from pyrogram.mime_types import mime_types
 
+from module.app import DownloadStatus, DownloadTaskNode
+
 _mimetypes = MimeTypes()
 _mimetypes.readfp(StringIO(mime_types))
+_download_cache = Cache(1024 * 1024 * 1024)
+
+
+def reset_download_cache():
+    """Reset download cache"""
+    _download_cache.store.clear()
 
 
 def _guess_mime_type(filename: str) -> Optional[str]:
@@ -77,3 +89,117 @@ def get_extension(file_id: str, mime_type: str) -> str:
         extension = ".unknown"
 
     return extension
+
+
+async def upload_telegram_chat(
+    client: pyrogram.Client,
+    upload_telegram_chat_id: Union[int, str],
+    message: pyrogram.types.Message,
+    file_name: str,
+):
+    """
+    Uploads a video or message to a Telegram chat.
+
+    Parameters:
+        client (pyrogram.Client): The pyrogram client.
+        upload_telegram_chat_id (Union[int, str]): The ID of the chat to upload to.
+        message (pyrogram.types.Message): The message to upload.
+        file_name (str): The name of the file to upload.
+    """
+    if message.video:
+        await client.send_video(
+            upload_telegram_chat_id, file_name, caption=message.caption
+        )
+    elif message.photo:
+        await client.send_photo(
+            upload_telegram_chat_id, file_name, caption=message.caption
+        )
+    elif message.document:
+        await client.send_document(
+            upload_telegram_chat_id, file_name, caption=message.caption
+        )
+    elif message.voice:
+        await client.send_voice(
+            upload_telegram_chat_id, file_name, caption=message.caption
+        )
+    elif message.video_note:
+        await client.send_video_note(
+            upload_telegram_chat_id, file_name, caption=message.caption
+        )
+    elif message.text:
+        await client.send_message(upload_telegram_chat_id, message.text)
+
+
+def record_download_status(func):
+    """Record download status"""
+
+    @wraps(func)
+    async def inner(
+        client: pyrogram.client.Client,
+        message: pyrogram.types.Message,
+        media_types: List[str],
+        file_formats: dict,
+        chat_id: Union[int, str],
+    ):
+        if _download_cache[(chat_id, message.id)] is DownloadStatus.Downloading:
+            return DownloadStatus.Downloading, None
+
+        _download_cache[(chat_id, message.id)] = DownloadStatus.Downloading
+
+        status, file_name = await func(
+            client, message, media_types, file_formats, chat_id
+        )
+
+        _download_cache[(chat_id, message.id)] = status
+
+        return status, file_name
+
+    return inner
+
+
+async def report_bot_status(
+    client: pyrogram.Client,
+    node: DownloadTaskNode,
+    message: pyrogram.types.Message,
+    download_status: DownloadStatus,
+):
+    """
+    Sends a message with the current status of the download bot.
+
+    Parameters:
+        client (pyrogram.Client): The client instance.
+        node (DownloadTaskNode): The download task node.
+        message (pyrogram.types.Message): The message object.
+        download_status (DownloadStatus): The current download status.
+
+    Returns:
+        None
+    """
+    node.stat(download_status)
+    if node.can_reply():
+        await client.edit_message_text(
+            node.from_user_id,
+            node.reply_message_id,
+            f"{node.reply_message}\n"
+            f"**total**: `{node.total_download_task}`\n"
+            f"**success**: `{node.success_download_task}`\n"
+            f"**failed**: `{node.failed_download_task}`\n"
+            f"**skip**: `{node.skip_download_task}`\n"
+            f"**status**:\n"
+            f"  * message id : `{message.id}`\n"
+            f"  * status: **{download_status.name}**",
+        )
+
+
+def set_max_concurrent_transmissions(
+    client: pyrogram.Client, max_concurrent_transmissions: int
+):
+    """Set maximum concurrent transmissions"""
+    if getattr(client, "max_concurrent_transmissions", None):
+        client.max_concurrent_transmissions = max_concurrent_transmissions
+        client.save_file_semaphore = asyncio.Semaphore(
+            client.max_concurrent_transmissions
+        )
+        client.get_file_semaphore = asyncio.Semaphore(
+            client.max_concurrent_transmissions
+        )

--- a/tests/module/test_app.py
+++ b/tests/module/test_app.py
@@ -23,7 +23,7 @@ class AppTestCase(unittest.TestCase):
 
     def test_app(self):
         app = Application("", "")
-        self.assertEqual(app.save_path, os.path.abspath("."))
+        self.assertEqual(app.save_path, os.path.join(os.path.abspath("."), "downloads"))
         self.assertEqual(app.proxy, {})
         self.assertEqual(app.restart_program, False)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,5 @@
 import datetime
+import platform
 
 
 class Chat:
@@ -115,3 +116,10 @@ class MockVideoNote:
         self.mime_type = kwargs["mime_type"]
         self.file_id = "VIDEO_NOTE"
         self.date = kwargs["date"]
+
+
+def platform_generic_path(_path: str) -> str:
+    platform_specific_path: str = _path
+    if platform.system() == "Windows":
+        platform_specific_path = platform_specific_path.replace("/", "\\")
+    return platform_specific_path

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -27,6 +27,7 @@ class MockMessage:
         self.video_note = kwargs.get("video_note", None)
         self.media_group_id = kwargs.get("media_group_id", None)
         self.caption = kwargs.get("caption", None)
+        self.text = None
 
         if kwargs.get("dis_chat") == None:
             self.chat = Chat(

--- a/tests/test_media_downloader.py
+++ b/tests/test_media_downloader.py
@@ -974,7 +974,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
             res,
             (
                 DownloadStatus.SuccessDownload,
-                "\\root\\project\\-123\\0\\312 - sucess_down.mp4",
+                platform_generic_path("/root/project/-123/0/312 - sucess_down.mp4"),
             ),
         )
 

--- a/tests/utils/test_filter.py
+++ b/tests/utils/test_filter.py
@@ -25,6 +25,11 @@ def filter_exec(download_filter: Filter, filter_str: str) -> bool:
     return download_filter.exec(filter_str)
 
 
+def check_filter_exec(download_filter: Filter, filter_str: str) -> bool:
+    filter_str = replace_date_time(filter_str)
+    return download_filter.check_filter(filter_str)
+
+
 class FilterTestCase(unittest.TestCase):
     def test_string_filter(self):
         download_filter = Filter()
@@ -176,12 +181,11 @@ class FilterTestCase(unittest.TestCase):
         )
 
         # test not exist value
-        self.assertEqual(
-            filter_exec(
-                download_filter,
-                "message_date >= 2022.03.04 && message_date <= 2022.08.06 && not_exist == True",
-            ),
-            True,
+        self.assertRaises(
+            ValueError,
+            filter_exec,
+            download_filter,
+            "message_date >= 2022.03.04 && message_date <= 2022.08.06 && not_exist == True",
         )
 
         download_filter.set_debug(True)
@@ -241,3 +245,125 @@ class FilterTestCase(unittest.TestCase):
         self.assertEqual(filter_exec(download_filter, "caption == r'.*#中文.*'"), True)
 
         self.assertEqual(filter_exec(download_filter, "caption == r'.*#中文啊.*'"), False)
+
+    def test_check_filter(self):
+        download_filter = Filter()
+        meta = MetaData()
+
+        message = MockMessage(
+            id=5,
+            media=True,
+            date=datetime(2022, 8, 5, 14, 35, 12),
+            chat_title="test2",
+            caption=None,
+            video=MockVideo(
+                mime_type="video/mp4",
+                file_size=1024 * 1024 * 10,
+                file_name="test.mp4",
+                width=1920,
+                height=1080,
+                duration=35,
+            ),
+        )
+
+        meta.get_meta_data(message)
+
+        download_filter.set_debug(True)
+        download_filter.set_meta_data(meta)
+
+        # 1. ==
+        # 1.1 restring
+        self.assertEqual(
+            check_filter_exec(download_filter, "caption == rr'.*#中文啊.*'"),
+            (False, "Syntax error at '.*#中文啊.*'"),
+        )
+        self.assertEqual(
+            check_filter_exec(download_filter, "caption == r'.*#中文啊.*'"), (True, None)
+        )
+        self.assertEqual(
+            check_filter_exec(download_filter, "caption tis r'.*#中文啊.*'"),
+            (False, "Syntax error at 'tis'"),
+        )
+        # 1.2 string
+        self.assertEqual(
+            check_filter_exec(download_filter, "caption = '.*#中文啊.*'"), (True, None)
+        )
+
+        # 2. check type
+        # 2.1 str
+        self.assertEqual(
+            check_filter_exec(download_filter, "caption = 1"),
+            (False, "caption is str but 1 is not"),
+        )
+        self.assertEqual(
+            check_filter_exec(download_filter, "caption = 3KB"),
+            (False, "caption is str but 3072 is not"),
+        )
+        # 2.2 datetime
+        self.assertEqual(
+            check_filter_exec(download_filter, "message_date == '.*#中文啊.*'"),
+            (False, "2022-08-05 14:35:12 is datetime but .*#中文啊.* is not"),
+        )
+
+        # 2.3 int
+        self.assertEqual(
+            check_filter_exec(download_filter, "id == '.*'"),
+            (False, "5 is int but .* is not"),
+        )
+        self.assertEqual(
+            check_filter_exec(download_filter, "id == .*"),
+            (False, "Syntax error at '*'"),
+        )
+        self.assertEqual(
+            check_filter_exec(download_filter, "id == ."),
+            (False, "Syntax error at EOF"),
+        )
+        self.assertEqual(
+            check_filter_exec(download_filter, "id == ."),
+            (False, "Syntax error at EOF"),
+        )
+        # 2.3.1 custom token
+        self.assertEqual(
+            check_filter_exec(download_filter, "file_size == 3KB"), (True, None)
+        )
+        self.assertEqual(
+            check_filter_exec(download_filter, "file_size == 3kb"),
+            (False, "Syntax error at 'kb'"),
+        )
+
+        # 3. error name
+        self.assertEqual(
+            check_filter_exec(download_filter, "caption2 == .*#中文啊.*'"),
+            (False, "Undefined name caption2"),
+        )
+
+        # 4. datetime
+        self.assertEqual(
+            check_filter_exec(download_filter, "message_date == 2023/0b-05"),
+            (False, "Syntax error at 'b'"),
+        )
+        self.assertEqual(
+            check_filter_exec(download_filter, "message_date == 2023/01/45")[0], False
+        )
+
+    def test_normal(self):
+        download_filter = Filter()
+        print(download_filter.filter.names)
+        meta = MetaData("2022/03/08 10:00:00", 0, "#高桥千x", 0, 0, 0, "", 0)
+        download_filter.set_meta_data(meta)
+        self.assertEqual(check_filter_exec(download_filter, "id > 1"), (True, None))
+        download_filter.set_debug(True)
+        filter_exec(download_filter, "caption == r'.*高桥.*'")
+
+        download_filter2 = Filter()
+        meta2 = MetaData("2022/03/08 10:00:00", 0, "", 0, 0, 0, "", 0)
+        download_filter2.set_meta_data(meta2)
+        download_filter2.set_debug(True)
+        filter_exec(download_filter2, "caption == r'.*高桥.*'")
+        print(download_filter.filter.names)
+
+        download_filter.set_meta_data(meta)
+        self.assertEqual(check_filter_exec(download_filter, "id > 1"), (True, None))
+        download_filter.set_debug(True)
+        filter_exec(download_filter, "caption == r'.*高桥.*'")
+        filter_exec(download_filter, "caption == r'.*高桥.*'")

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -120,25 +120,18 @@ class FormatTestCase(unittest.TestCase):
         self.assertEqual(get_byte_from_str("2CB"), None)
 
     def test_extract_info_from_link(self):
-        link1 = "https://t.me/"
-        username, message_id = extract_info_from_link(link1)
-        self.assertEqual(username, None)
-        self.assertEqual(message_id, None)
+        test_cases = [
+            ("https://t.me/", (None, None)),
+            ("https://t.me/username/1234", ("username", 1234)),
+            ("https://t.me/username", ("username", None)),
+            ("https://t.me/c/213213/91011", (-100213213, 91011)),
+            ("me", ("me", None)),
+            ("self", ("self", None)),
+        ]
 
-        link1 = "https://t.me/username/1234"
-        username, message_id = extract_info_from_link(link1)
-        self.assertEqual(username, "username")
-        self.assertEqual(message_id, 1234)
-
-        link2 = "https://t.me/username"
-        username, message_id = extract_info_from_link(link2)
-        self.assertEqual(username, "username")
-        self.assertEqual(message_id, None)
-
-        link3 = "https://t.me/c/213213/91011"
-        username, message_id = extract_info_from_link(link3)
-        self.assertEqual(username, -100213213)
-        self.assertEqual(message_id, 91011)
+        for link, expected_output in test_cases:
+            result = extract_info_from_link(link)
+            self.assertEqual(result, expected_output)
 
 
 class TestTruncateFilename(unittest.TestCase):

--- a/utils/format.py
+++ b/utils/format.py
@@ -101,9 +101,12 @@ def get_date_time(text: str, fmt: str) -> SearchDateTimeResult:
         search_res = re.search(value, search_text)
         if search_res:
             time_str = search_res.group(0)
-            res.value = datetime.strptime(
-                time_str.replace("/", "-").replace(".", "-").strip(), format_list[i]
-            ).strftime(fmt)
+            try:
+                res.value = datetime.strptime(
+                    time_str.replace("/", "-").replace(".", "-").strip(), format_list[i]
+                ).strftime(fmt)
+            except Exception:
+                break
             if search_res.start() != 0:
                 res.left_str = search_text[0 : search_res.start()]
             if search_res.end() + 1 <= len(search_text):
@@ -219,3 +222,18 @@ def extract_info_from_link(link: str):
         return username, message_id
 
     return None, None
+
+
+def validate_title(title: str):
+    """Fix if title validation fails
+
+    Parameters
+    ----------
+    title: str
+        Chat title
+
+    """
+
+    r_str = r"[\//\:\*\?\"\<\>\|\n]"  # '/ \ : * ? " < > |'
+    new_title = re.sub(r_str, "_", title)
+    return new_title

--- a/utils/format.py
+++ b/utils/format.py
@@ -174,15 +174,13 @@ def get_byte_from_str(byte_str: str) -> Optional[int]:
             if it == unit_str:
                 break
             unit *= 1024
-        else:
-            raise ValueError(f"{byte_str} not support")
 
         return int(search_res.group(1)) * unit
 
     return None
 
 
-def truncate_filename(path: str, limit: int = 255) -> str:
+def truncate_filename(path: str, limit: int = 240) -> str:
     """Truncate filename to the max len.
 
     Parameters
@@ -213,7 +211,7 @@ def extract_info_from_link(link: str):
     if channel_match:
         chat_id = f"-100{channel_match.group(1)}"
         message_id = int(channel_match.group(2)) if channel_match.group(2) else None
-        return chat_id, message_id
+        return int(chat_id), message_id
 
     username_match = re.match(r"(?:https?://)?t\.me/(\w+)(?:/(\d+))?", link)
     if username_match:

--- a/utils/format.py
+++ b/utils/format.py
@@ -207,6 +207,9 @@ def truncate_filename(path: str, limit: int = 240) -> str:
 
 def extract_info_from_link(link: str):
     """Extract info from link"""
+    if link in ("me", "self"):
+        return link, None
+
     channel_match = re.match(r"(?:https?://)?t\.me/c/(\w+)(?:/(\d+))?", link)
     if channel_match:
         chat_id = f"-100{channel_match.group(1)}"

--- a/utils/meta_data.py
+++ b/utils/meta_data.py
@@ -42,7 +42,7 @@ class MetaData:
 
     def __init__(
         self,
-        message_date: int = None,
+        message_date: str = None,
         message_id: int = None,
         message_caption: str = None,
         media_file_size: int = None,


### PR DESCRIPTION
## 新功能
*  bot 支持更多命令，下载，转发均支持`过滤器`
    * `/download` - 下载消息
    * `/forward` - 转发消息
    * `/listen_forward` - 监听转发消息
    * `/set_language` - 设置语言
* 所有下载转发增加过滤表达式
* 添加配置中过滤表达式校验
## 修复
* 多个过滤表达式校验有问题
* 稳定性问题，长时间下载会出现fileReferceExpire , 修改代码，重新测试
* 临时文件名称重复，导致下载失败
* 重复下发命令导致出错
  * 建立全局消息库，按照chat-id,meesage-id, status,下载状态，如果下载才开始则跳过，如果下载成功则跳过
  * 转发重复下发，建立转发全局消息库，按照chat-id，message-id，status转发状态 暂时不解决
* 修复一组视频或者图片，过滤器过滤caption的时候，会少数据
  * 第一阶段，采用下载一样的方式加载
* 只有bot_token退出报错

## feature
* bot supports more commands, downloading and forwarding all support `filter`
     * `/download` - download message
     * `/forward` - forward message
     * `/listen_forward` - listen for forwarded messages
     * `/set_language` - set language
* Add filter expression for all download forwarding
* Add filter expression validation in configuration
## fix
* There is a problem with the validation of multiple filter expressions
* Stability problem, fileReferceExpire will appear when downloading for a long time, modify the code and retest
* The name of the temporary file is duplicated, causing the download to fail
* Repeatedly issuing commands leads to errors
   * Establish a global message library, according to chat-id, meesage-id, status, download status, skip if the download starts, skip if the download is successful
   * Forwarding is sent repeatedly, and a forwarding global message library is established, and the forwarding status is forwarded according to chat-id, message-id, and status. Temporarily unresolved
* Repair a group of videos or pictures, when the filter filters the caption, there will be less data
   * In the first stage, load in the same way as downloading
* Only bot_token exits and reports an error