### PR TITLE
跳过的下载记录不添加到data.yaml里面

### DIFF
--- a/module/app.py
+++ b/module/app.py
@@ -796,13 +796,13 @@ class Application:
             unfinished_ids = set(value.ids_to_retry)
 
             for it in value.ids_to_retry:
-                if DownloadStatus.SuccessDownload == value.node.download_status.get(
+                if  value.node.download_status.get(
                     it, DownloadStatus.FailedDownload
-                ):
+                ) in [DownloadStatus.SuccessDownload, DownloadStatus.SkipDownload]:
                     unfinished_ids.remove(it)
 
             for _idx, _value in value.node.download_status.items():
-                if DownloadStatus.SuccessDownload != _value:
+                if DownloadStatus.SuccessDownload != _value and DownloadStatus.SkipDownload != _value:
                     unfinished_ids.add(_idx)
 
             self.chat_download_config[key].ids_to_retry = list(unfinished_ids)


### PR DESCRIPTION
原代码中只要不成功就会添加到 未完成的数组 unfinished_ids里， 如果使用过滤器筛选的也会加入到里面，再次下载会把跳过的内容给下载。加个判断条件，不加入data.yaml 里面