### PR TITLE
fix: update_config before docker exit (#135)

### DIFF
--- a/media_downloader.py
+++ b/media_downloader.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os
 import shutil
+import signal
 import time
 from typing import List, Optional, Tuple, Union
 
@@ -646,8 +647,19 @@ async def stop_server(client: pyrogram.Client):
     await client.stop()
 
 
+def setup_exit_signal_handlers():
+    def signal_exit(signum, _):
+        logger.debug(f"Received signal: {signum}. Graceful Exit...")
+        raise KeyboardInterrupt()
+
+    signal.signal(signal.SIGINT, signal_exit)
+    signal.signal(signal.SIGTERM, signal_exit)
+
+
 def main():
     """Main function of the downloader."""
+    setup_exit_signal_handlers()
+
     tasks = []
     client = HookClient(
         "media_downloader",


### PR DESCRIPTION
## Problem | 问题
Docker 部署后，Config.yaml 未正确更新。
Config.yaml was not updated properly after Docker deployment.

## Solution | 解决
添加了信号（signal）监听，确保在 Docker 收到退出信号时正确更新 Config.yaml。
Added signal handling to properly update Config.yaml when Docker receives exit signals.

## Related Issue |相关
关闭问题 #135
Close #135