### PR TITLE
fix: avoid falling back to copy files when moving files in docker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,8 @@ services:
     volumes:
       # Here is what you need to edit
       - "./downloads/:/app/downloads/"
-
+      # Not recommend,this will cause move files back to copy files
+      #- "./temp/:/app/downloads/temp"
       # Rclone
       - "$HOME/.config/rclone/:$HOME/.config/rclone/"
 
@@ -22,7 +23,7 @@ services:
       - "./data.yaml:/app/data.yaml"
       - "./log/:/app/log/"
       - "./sessions/:/app/sessions"
-      - "./temp/:/app/temp"
+
     #restart: "unless-stopped"
 # volumes:
 #   sessions:

--- a/module/app.py
+++ b/module/app.py
@@ -372,7 +372,7 @@ class Application:
         self.chat_download_config: dict = {}
 
         self.save_path = os.path.join(os.path.abspath("."), "downloads")
-        self.temp_save_path = os.path.join(os.path.abspath("."), "temp")
+        self.temp_save_path = os.path.join(os.path.abspath("."), "downloads/temp")
         self.api_id: str = ""
         self.api_hash: str = ""
         self.bot_token: str = ""


### PR DESCRIPTION
`shutil.move()` 函数是 Python `shutil` 模块中用于移动文件或目录的函数。理想情况下，它会执行一个重命名操作，这个操作非常快，因为它只需要更新元数据（**比如文件名和文件在文件系统目录结构中的位置**），而不需要实际复制数据。

Docker 容器中的路径 ./download:/app/download 和 ./temp:/app/temp 会被 shutil.move() 判定为位于不同的文件系统，即使它们看起来都在 /download 目录下.      
           
