### PR TITLE
fix:解决在使用目录代理访问web界面时静态资源加载失败的问题

### DIFF
--- a/module/templates/index.html
+++ b/module/templates/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Telegram Media Downloader</title>
-  <link href="{{ url_for('static', filename='layui/css/layui.css') }}" rel="stylesheet">
-  <link href="{{ url_for('static', filename='css/index.css') }}" rel="stylesheet">
+  <link href="static/layui/css/layui.css" rel="stylesheet">
+  <link href="static/css/index.css" rel="stylesheet">
   <style>
     body {
       padding: 6px 16px;
@@ -62,7 +62,7 @@
     </div>
   </div>
 
-  <script src="../static/layui/layui.js"></script>
+  <script src="static/layui/layui.js"></script>
   <script>
 
     layui.use(['table', 'element'], function () {


### PR DESCRIPTION
调整了index.html中js和css静态资源的路径。
直接访问和使用目录代理访问目前都可以正确加载静态资源。