### PR TITLE
fix: handle SIGTERM signal to gracefully terminate the application

### DIFF
--- a/media_downloader.py
+++ b/media_downloader.py
@@ -1,5 +1,6 @@
 """Downloads media from telegram."""
 import asyncio
+import signal
 import logging
 import os
 import shutil
@@ -698,6 +699,11 @@ def main():
             f"{app.cloud_drive_config.total_upload_success_file_count}"
         )
 
+
+def handle_sigterm(signum, frame):
+    raise KeyboardInterrupt
+
+signal.signal(signal.SIGTERM, handle_sigterm)
 
 if __name__ == "__main__":
     if _check_config():


### PR DESCRIPTION
这个拉取请求为 `media_downloader.py` 脚本添加了对 SIGTERM 信号的处理。这确保了如果进程收到终止信号，它将引发 `KeyboardInterrupt` 并干净地退出。

信号处理改进：

*  导入了 `signal` 模块以启用信号处理功能。
*  添加了 `handle_sigterm` 函数并将其注册为处理 SIGTERM 信号，在触发时引发 `KeyboardInterrupt`。

主要用于docker容器的停止。